### PR TITLE
test: matplotlib backend side-effects

### DIFF
--- a/tests/notebooks/notebook_plotting.ipynb
+++ b/tests/notebooks/notebook_plotting.ipynb
@@ -1,0 +1,114 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import pytest\n",
+    "\n",
+    "from pandas_profiling import ProfileReport\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import requests\n",
+    "from IPython.display import display\n",
+    "from IPython.utils.capture import capture_output, CapturedIO\n",
+    "import IPython.utils\n",
+    "\n",
+    "\n",
+    "import pandas_profiling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## import matplot lib after importing pandas profiling to recreate Issue #888, 837\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with capture_output() as out_matplot:\n",
+    "    plt.plot([1, 2, 3, 4])\n",
+    "    plt.ylabel('some numbers in a pyplot')\n",
+    "    plt.show()\n",
+    "    \n",
+    "assert len(out_matplot.outputs) == 1\n",
+    "assert \"<Figure\" in out_matplot.outputs[0].data[\"text/plain\"] \n",
+    "assert len(out_matplot.outputs[0].data[\"image/png\"]) > 0 #assert an image actually exists\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8/fFQqAAAACXBIWXMAAAsTAAALEwEAmpwYAAAin0lEQVR4nO3deVxVdf7H8ddXBVFEXMAVEfeFxQ01bdG0KTXLzJpqyhYrq2lqfjO/SU1rtHTKtKZp2hxrrJyamlHQTEvbLC210ko2N8QNNxAUUESW+/39ATMPf6aBcuHc5f18PHgEnuM97+OFd4dzz/lcY61FRES8Xx2nA4iIiHuo0EVEfIQKXUTER6jQRUR8hApdRMRH1HNqw2FhYTYqKsqpzYuIeKVNmzYdsdaGn22ZY4UeFRXFxo0bndq8iIhXMsbsOdcynXIREfERKnQRER+hQhcR8RGOnUM/m5KSEjIzMykqKnI6So0ICgoiIiKCgIAAp6OIiA/yqELPzMwkJCSEqKgojDFOx3Eray05OTlkZmbSoUMHp+OIiA+q9JSLMaadMWa1MSbNGJNqjPntWdYxxpi/GmPSjTFJxpi+FxKmqKiI5s2b+1yZAxhjaN68uc/+9iEizqvKEXop8L/W2u+NMSHAJmPMJ9batNPWGQl0qfgYCLxa8d/z5otl/h++vG8i4rxKj9CttQettd9XfF4AbAHanrHaGGChLbcBaGKMae32tCIiXqykzMUrX6Szed+xGnn887rKxRgTBfQBvjljUVtg32lfZ/LT0scYM9EYs9EYszE7O/s8o3qeGTNm8OyzzwKwaNEioqOjqVOnjm6YEpGfSNmfx3Uvf82cldv4KOVQjWyjyoVujGkEJAD/Y63Nv5CNWWvnW2vjrbXx4eFnvXPVa8XExJCYmMhll13mdBQR8SBFJWXMXbWVMS9/zeH8U7x6a1+mjOxeI9uqUqEbYwIoL/N3rLWJZ1llP9DutK8jKv7MKy1cuJC4uDh69erF+PHj2b17N8OGDSMuLo7hw4ezd+/en/ydHj160K1bNwfSioin2rg7l1F/XcvLq3dyfZ+2fPb7IYyMrbmz0ZW+KGrKX8n7O7DFWvvnc6y2DPiNMeY9yl8MzbPWHqxOsCc+SCXtwAX9InBOPds0Zvo10T+7TmpqKrNmzWLdunWEhYWRm5vLHXfc8d+PBQsW8PDDD7N06VK3ZhMR33H8VClzV25l4YY9tAltwMIJA7isa82flajKVS4XA+OBZGPMjxV/NhWIBLDWzgM+BEYB6UAhcJfbk9aSzz//nBtvvJGwsDAAmjVrxvr160lMLP/FZPz48UyaNMnJiCLiwb7cns3UxGQO5J3kjkFRPHJVN4Lr184tP5VuxVr7FfCz19vZ8neaftBdoYBKj6RFRDzJscJiZi7fQsL3mXQKD2bRfYOIj2pWqxk0y+UMw4YNY9GiReTk5ACQm5vL4MGDee+99wB45513uPTSS52MKCIe5qPkg1zx5zUs/XE/v7m8MysevrTWyxw87NZ/TxAdHc20adMYMmQIdevWpU+fPrz44ovcddddzJ07l/DwcN54442f/L0lS5bw0EMPkZ2dzdVXX03v3r1ZtWqVA3sgIrUlK7+IP76fysrUQ8S0bcxbE/oT3SbUsTym/GxJ7YuPj7dnXq+9ZcsWevTo4Uie2uIP+yji66y1LNqUyazlaRSVuvjdFV2599IO1Ktb8yc9jDGbrLXxZ1umI3QRkfOwL7eQqUuSWbvjCAOimjF7XCwdwxs5HQtQoYuIVEmZy7Jw/W7mrtqGAWaOiebWge2pU8dzZjR5XKFba312iJVTp7dEpHrSswqYnJDMpj1HGdI1nKeuj6VtkwZOx/oJjyr0oKAgcnJyfHKE7n/moQcFBTkdRUSqqKTMxd++3MlfP0unYf26PH9TL67r3dZj+8mjCj0iIoLMzEx8YXDX2fznHYtExPMlZ+YxKSGJLQfzuTquNU9cG01Yo/pOx/pZHlXoAQEBejcfEXFUUUkZf/l0B6+tzaB5cCB/G9+Pq6JbOR2rSjyq0EVEnPRNRg5TEpPZdeQEN8W3Y+rVPQht4D3vAaxCFxG/V1BUwpyV2/jHhj20a9aAd+4ZyMWdw5yOdd5U6CLi11Zvy2JaYjIH84uYcHEH/nBVVxoGemc1emdqEZFqOnqimJnL00j8YT9dWjQi4YHB9I1s6nSsalGhi4hfsdayIvkg099PJe9kCQ8P78KDl3eifr26TkerNhW6iPiNw/lFPLY0hU/SDhMXEcrb9wykR+vGTsdyGxW6iPg8ay3/3riPWSu2UFzqYuqo7ky4uHaGadUmFbqI+LS9OYVMSUxi3c4cBnZoxjPj4ogKC3Y6Vo1QoYuITypzWd5ct5tnV22jbh3Dn8bGcEv/SI8apuVuKnQR8TnbDxcwaXESP+47xrDuLfjT2Bhah3reMC13U6GLiM8oLnXx6hc7eWn1DkKCAnjh5t5c26uNxw7TcjcVuoj4hM37jjE5IYmthwq4tlcbpl/Tk+YePkzL3VToIuLVThaX8fyn23l9bQYtQoJ4/fZ4rujZ0ulYjlChi4jXWr8zh0cTk9idU8gtAyJ5dFR3Ggd5zzAtd1Ohi4jXyS8qYfZHW/nnN3tp37wh/7x3IIM7ed8wLXdToYuIV/lsy2GmLUkhq6CIiZd15HdXdKVBoPfftu8OKnQR8Qo5x0/xxAdpLNt8gG4tQ5g3vh+92zVxOpZHUaGLiEez1rJs8wGe+CCNgqISfndFVx4Y2onAer512747qNBFxGMdzDvJY0tS+GxrFr3aNWHOuDi6tQpxOpbHUqGLiMdxuSzvfbePpz/cQonLxWNX9+CuiztQ14dv23cHFbqIeJTdR04wJTGJDRm5DO7UnKevj6V9c98cpuVuKnQR8QilZS4WfL2L5z7eTmDdOsy+Ppab+rfzm9v23aHSQjfGLABGA1nW2pizLA8F3gYiKx7vWWvtG+4OKiK+a+uhfCYvTmJzZh5X9GjJrOtiaBUa5HQsr1OVI/Q3gZeAhedY/iCQZq29xhgTDmwzxrxjrS12U0YR8VGnSst4efVOXlmdTmiDAF68pQ+j41rrqPwCVVro1to1xpion1sFCDHlz0AjIBcodU88EfFVP+w9yuSEJLYfPs7YPm15fHRPmgUHOh3Lq7njHPpLwDLgABAC3GStdZ1tRWPMRGAiQGRkpBs2LSLeprC4lOc+3s6Cr3fRqnEQC+6MZ1h3/xym5W7uKPSrgB+BYUAn4BNjzFprbf6ZK1pr5wPzAeLj460bti0iXmRd+hGmJCazN7eQ2y6KZPKI7oT48TAtd3NHod8FzLbWWiDdGLML6A5864bHFhEfkHeyhKc/3MJ73+2jQ1gw/5p4EQM7Nnc6ls9xR6HvBYYDa40xLYFuQIYbHldEfMDHqYd4bGkKR46f4r4h5cO0ggI0TKsmVOWyxXeBoUCYMSYTmA4EAFhr5wEzgTeNMcmAASZba4/UWGIR8QpHjp9ixrJUlicdpHurEF6/I564iCZOx/JpVbnK5ZZKlh8ArnRbIhHxatZalv64nyc+SKPwVBn/+4uu3D+0EwF1NUyrpulOURFxmwPHTjJtSTKrt2XTJ7J8mFaXlhqmVVtU6CJSbS6X5Z1v9zL7wy24LEy/pie3D4rSMK1apkIXkWrJyD7OlIRkvt2dyyWdw3j6+ljaNWvodCy/pEIXkQtSWubi9a928fwn26lfrw5zbojjxn4Rum3fQSp0ETlvaQfymZSwmZT9+VwV3ZKZY2Jo0VjDtJymQheRKjtVWsZLn6fz6hc7adIwgFdu7cvImFY6KvcQKnQRqZJNe3KZnJBMetZxxvWN4LGre9BUw7Q8igpdRH7WiVOlzF21jbfW76ZNaAPemjCAIV3DnY4lZ6FCF5FzWrsjm0cTk8k8epI7BrXnkRHdaVRfteGp9MyIyE/kFZYwa0UaizZl0jE8mEX3D6J/VDOnY0klVOgi8v+sTDnE4++nkHuimF8P7cTDw7tomJaXUKGLCABZBUXMWJbKh8mH6Nm6MW/c2Z+YtqFOx5LzoEIX8XPWWhK+38/M5WmcLCnjkau6MfGyjhqm5YVU6CJ+LPNoIVOXpLBmezbx7Zsye1wcnVs0cjqWXCAVuogfcrks/9iwh2dWbgXgiWujGX9Re+pomJZXU6GL+Jmd2ceZvDiJjXuOclnXcJ4aG0NEUw3T8gUqdBE/UVLmYv6aDF74bAcNAury7I29GNe3rW7b9yEqdBE/kLI/j0mLk0g7mM+o2FbMuDaaFiEapuVrVOgiPqyopIwXPtvB/DUZNAsOZN5tfRkR09rpWFJDVOgiPuq73blMXpxExpET3Ngvgseu7klowwCnY0kNUqGL+Jjjp0qZs3IrC9fvIaJpA/5x9wAu7aJhWv5AhS7iQ77cns3UxGQO5J3kzsFRPHJVN4I1TMtv6JkW8QHHCot5cnkaid/vp1N4MIvvH0S/9hqm5W9U6CJezFrLRymH+OP7KRwrLOE3l3fmN8M6a5iWn1Khi3iprPwiHn8/hVWph4lp25i3Jgwguo2GafkzFbqIl7HWsmhTJrOWp3Gq1MWUkd2555IO1NMwLb+nQhfxIvtyC3k0MZmv0o8wIKoZs8fF0jFcw7SknApdxAuUuSwL1+9mzspt1DEw87oYbh0QqWFa8v+o0EU83I7DBUxOSOL7vccY2i2cP42NpW2TBk7HEg+kQhfxUCVlLuZ9sZMXP08nuH5dnr+pF9f11jAtObdKC90YswAYDWRZa2POsc5Q4C9AAHDEWjvEfRFF/E9yZh6PLN7M1kMFjI5rzYxrowlrVN/pWOLhqnKE/ibwErDwbAuNMU2AV4AR1tq9xpgWbksn4meKSsp4/tPtvLYmg7BG9Zk/vh9XRrdyOpZ4iUoL3Vq7xhgT9TOr/ApItNburVg/y03ZRPzKNxk5TElMZteRE9zcvx2PjupBaAMN05Kqc8c59K5AgDHmCyAEeMFae66j+YnARIDIyEg3bFrE+xUUlfDMyq28vWEv7Zo14J17BnJx5zCnY4kXckeh1wP6AcOBBsB6Y8wGa+32M1e01s4H5gPEx8dbN2xbxKut3prF1CXJHMov4u5LOvC/V3alYaCuVZAL447vnEwgx1p7AjhhjFkD9AJ+UugiUi73RDFPfpDK0h8P0KVFIxIeGEzfyKZOxxIv545Cfx94yRhTDwgEBgLPu+FxRXyOtZblSQeZsSyVvJMl/HZ4F359eSfq19MwLam+qly2+C4wFAgzxmQC0ym/PBFr7Txr7RZjzEogCXABr1trU2ousoh3OpxfxLQlKXy65TBxEaG8c+9Aurdq7HQs8SFVucrlliqsMxeY65ZEIj7GWsu/vtvHnz7cQnGpi2mjenDXxVEapiVup1dfRGrQnpwTPJqYzLqdOQzs0IxnxsURFRbsdCzxUSp0kRpQ5rK88fUunv14G/Xq1OGpsbHc3L+dhmlJjVKhi7jZtkMFTEpIYvO+Ywzv3oJZY2NoHaphWlLzVOgiblJc6uKVL9J5eXU6IUEBvHBzb67t1UbDtKTWqNBF3GDzvmNMWpzEtsMFjOndhj+O7klzDdOSWqZCF6mGk8Vl/PmTbfz9q120CAni9dvjuaJnS6djiZ9SoYtcoHU7j/BoYjJ7cgr51cBIpozsTuMgDdMS56jQRc5TflEJT3+4lXe/3Uv75g35570DGdxJw7TEeSp0kfPwadphpi1NJrvgFBMv68jvruhKg0Ddti+eQYUuUgU5x0/xxAdpLNt8gO6tQpg/Pp5e7Zo4HUvk/1Ghi/wMay3LNh9gxrJUjp8q5XdXdOWBoZ0IrKfb9sXzqNBFzuFg3kkeW5LCZ1uz6N2uCXNuiKNryxCnY4mckwpd5Awul+Xd7/by9IdbKXW5eOzqHtx1cQfq6rZ98XAqdJHT7DpygikJSXyzK5fBnZoz+/o4Ips3dDqWSJWo0EWA0jIXC77exXMfbyewXh2eGRfLL+Pb6bZ98SoqdPF7Ww7mMzkhiaTMPH7RsyWzrouhZeMgp2OJnDcVuvitU6VlvLx6J6+sTie0QQAv/aoPV8e21lG5eC0Vuvil7/ceZfLiJHZkHWdsn7b8cXRPmgYHOh1LpFpU6OJXCotLeXbVdt5Yt4tWjYN4487+XN69hdOxRNxChS5+4+v0I0xJTGJf7knGX9SeSSO6EaJhWuJDVOji8/JOlvDUii38a+M+OoQF86+JFzGwY3OnY4m4nQpdfNrHqYd4bGkKOSeKuX9IJ/7nii4EBWiYlvgmFbr4pOyCU8z4IJUVSQfp0boxf7+jP7ERoU7HEqlRKnTxKdZalvywnyeXp1F4qow/XNmV+4Z0IqCuhmmJ71Ohi8/Yf+wk05Yk88W2bPpGlg/T6txCw7TEf6jQxeu5XJZ3vtnD7I+24rIw/Zqe3D4oSsO0xO+o0MWrZWQfZ0pCMt/uzuXSLmE8NTaWds00TEv8kwpdvFJpmYvX1u7i+U+3E1SvDnNviOOGfhG6bV/8mgpdvE7qgTwmJySRsj+fq6JbMnNMDC00TEtEhS7eo6ikjBc/38G8LzNo2jCQV2/ty8jY1k7HEvEYKnTxCpv25DJpcRI7s08wrm8Ej4/uQZOGGqYlcrpKL841xiwwxmQZY1IqWa+/MabUGHOD++KJvztxqpQZy1K5Yd56ikpcvDVhAM/9spfKXOQsqnKE/ibwErDwXCsYY+oCzwAfuyeWCKzZns2jickcyDvJ7Re155ER3WlUX79UipxLpT8d1to1xpioSlZ7CEgA+rsjlPi3vMISZq5IY/GmTDqGB/Pv+wbRP6qZ07FEPF61D3eMMW2BscDlVFLoxpiJwESAyMjI6m5afNDKlIM8/n4quSeK+fXQTjw8XMO0RKrKHb+//gWYbK11VXYNsLV2PjAfID4+3rph2+IjsgqKmP5+Kh+lHKJn68a8cWd/YtpqmJbI+XBHoccD71WUeRgwyhhTaq1d6obHFh9nrWXxpkxmrdjCyZIyJo3oxr2XdtQwLZELUO1Ct9Z2+M/nxpg3geUqc6mKfbmFTF2SzNodR+gf1ZTZ4+LoFN7I6VgiXqvSQjfGvAsMBcKMMZnAdCAAwFo7r0bTiU9yuSwL1+9mzqptGODJMdHcNrA9dTRMS6RaqnKVyy1VfTBr7Z3VSiM+Lz3rOFMSkti45yiXdQ3nqbExRDTVMC0Rd9BFvVIrSspczF+TwQuf7qBBYF2eu7EX1/dtq2FaIm6kQpcal7I/j0mLk0g7mM+o2FY8cW0M4SH1nY4l4nNU6FJjikrKeOGzHcxfk0Gz4EDm3daPETGtnI4l4rNU6FIjvtudy+TFSWQcOcEv4yOYNqonoQ0DnI4l4tNU6OJWx0+VMmflVhau30NE0wa8ffdALukS5nQsEb+gQhe3Wb0ti2mJyRzML+Kui6P4w5XdCNYwLZFao582qbajJ4qZuTyNxB/207lFIxbfP5h+7Zs6HUvE76jQ5YJZa/kw+RDTl6VwrLCEh4Z15jfDOlO/noZpiThBhS4XJCu/iMeWpvBx2mFi24aycMJAerZp7HQsEb+mQpfzYq1l0cZMZq5Io7jUxaMju3P3JR2op2FaIo5ToUuV7cst5NHEZL5KP8KADs2YfX0sHTVMS8RjqNClUmUuy1vrdjN31Tbq1jHMui6GXw2I1DAtEQ+jQpefteNwAZMSkvhh7zGGdgvnqbGxtGnSwOlYInIWKnQ5q+JSF/O+3MlLn6cTXL8uf7mpN2N6t9EwLREPpkKXn0jKPMakxUlsPVTANb3aMP2anoQ10jAtEU+nQpf/Kiop4/lPtvPa2gzCQ+rz2u3x/KJnS6djiUgVqdAFgA0ZOUxJSGJ3TiG3DGjHlJE9CG2gYVoi3kSF7ucKikqY/dFW3vlmL5HNGvLPewYyuLOGaYl4IxW6H/t862GmLUnhcH4R91zSgd9f2ZWGgfqWEPFW+un1Q7kninnyg1SW/niAri0b8cqtg+kTqWFaIt5Ohe5HrLV8kHSQGctSKSgq4bfDu/Dg5Z0JrKfb9kV8gQrdTxzKKx+m9emWw/SKCOWZGwbSvZWGaYn4EhW6j7PW8t53+3hqxRZKXC6mjerBhEs6UFe37Yv4HBW6D9uTc4IpCcmsz8jhoo7NmH19HFFhwU7HEpEaokL3QWUuyxtf7+LZj7cRUKcOT42N5eb+7TRMS8THqdB9zLZD5cO0Nu87xvDuLZg1NobWoRqmJeIPVOg+orjUxStfpPPy6nRCggL46y19uCautYZpifgRFboP+HHfMSYvTmLb4QLG9G7D9GuiaRYc6HQsEallKnQvdrK4jOc+3saCr3fRIiSIv98Rz/AeGqYl4q9U6F5q3c4jTElIZm9uIb8aGMmUkd1pHKRhWiL+rNJCN8YsAEYDWdbamLMsvxWYDBigAHjAWrvZ3UGlXH5RCU9/uIV3v91H++YNeffeixjUqbnTsUTEA1TlCP1N4CVg4TmW7wKGWGuPGmNGAvOBge6JJ6f7NO0w05Ymk11wivsu68j/XNGVBoF1nY4lIh6i0kK31q4xxkT9zPJ1p325AYhwQy45Tc7xU8z4II0PNh+ge6sQXrs9nriIJk7HEhEP4+5z6HcDH51roTFmIjARIDIy0s2b9j3WWt7/8QBPfJDK8VOl/P4XXbl/SCcN0xKRs3JboRtjLqe80C851zrW2vmUn5IhPj7eumvbvujAsZM8tjSFz7dm0btdE+bcEEfXliFOxxIRD+aWQjfGxAGvAyOttTnueEx/5XJZ/vntXmZ/tJUyl+Xx0T25c3CUhmmJSKWqXejGmEggERhvrd1e/Uj+a9eRE0xJSOKbXblc3Lk5T4+NI7J5Q6djiYiXqMpli+8CQ4EwY0wmMB0IALDWzgP+CDQHXqm4zbzUWhtfU4F9UWmZi79/tYs/f7KdwHp1mDMujhvjI3Tbvoicl6pc5XJLJcvvAe5xWyI/k3Ygn8kJSSTvz+MXPVsy67oYWjYOcjqWiHgh3SnqkFOlZbz0eTqvfrGTJg0DePlXfRkV20pH5SJywVToDti05yiTE5JIzzrO9X3a8vjonjTVMC0RqSYVei0qLC5l7qptvLluN60bB/HGXf25vFsLp2OJiI9QodeSr3YcYUpiEplHTzL+ovZMGtGNEA3TEhE3UqHXsLyTJfxpRRr/3phJh7Bg/n3fIAZ0aOZ0LBHxQSr0GrQq9RCPL00h50QxDwztxG+HdyEoQMO0RKRmqNBrQHbBKWYsS2VF8kF6tG7M3+/oT2xEqNOxRMTHqdDdyFpL4vf7eXJ5GieLy3jkqm5MvKwjAXU1TEtEap4K3U32HzvJ1MRkvtyeTd/I8mFanVtomJaI1B4VejW5XJa3v9nDMx9txQIzrunJ+EEapiUitU+FXg07s48zJSGJ73Yf5dIuYTw1NpZ2zTRMS0ScoUK/ACVlLl5bm8FfPt1BUL06zL0hjhv6aZiWiDhLhX6eUvbnMTkhidQD+YyIbsWT10XTIkTDtETEeSr0KioqKePFz3cw78sMmjYM5NVb+zIytrXTsURE/kuFXgUbd+cyKSGJjOwTjOsbweOje9CkoYZpiYhnUaH/jBOnyodpvbV+N21CG/DWhAEM6RrudCwRkbNSoZ/Dl9uzmZqYzIG8k9wxKIpHrupGcH39c4mI51JDneFYYTEzl28h4ftMOoYHs+i+QcRHaZiWiHg+FfppPko+yOPvp3K0sJgHL+/EQ8M0TEtEvIcKHcjKL+KP76eyMvUQ0W0a89aE/kS30TAtEfEufl3o1loWb8pk5vI0ikpdTB7RnXsu7aBhWiLilfy20PflFjJ1STJrdxyhf1RTZo+Lo1N4I6djiYhcML8r9DKX5R/rdzNn1TYMMHNMNLcObE8dDdMSES/nV4WenlXA5IRkNu05ypCu4fxpbAwRTTVMS0R8g18UekmZi799uZO/fpZOw/p1+fMvezG2T1sN0xIRn+LzhZ6yP49HFiex5WA+V8e2Zsa10YSH1Hc6loiI2/lsoReVlPGXT3fw2toMmgUHMu+2foyIaeV0LBGRGuOThf7trlymJCSRceQEN8W3Y+qoHoQ2DHA6lohIjfKpQi8oKmHOym38Y8MeIpo24O27B3JJlzCnY4mI1AqfKfTV27KYlpjMwfwiJlzcgT9c1ZWGgT6zeyIilfL6xjt6opiZy9NI/GE/nVs0YvH9g+nXvqnTsUREal2lhW6MWQCMBrKstTFnWW6AF4BRQCFwp7X2e3cHPZO1lhXJB5n+fip5J0t4eFhnHhzWmfr1NExLRPxTVY7Q3wReAhaeY/lIoEvFx0Dg1Yr/1pjD+UU8vjSFj9MOE9s2lLfvGUiP1o1rcpMiIh6v0kK31q4xxkT9zCpjgIXWWgtsMMY0Mca0ttYedFfI063emsXD7/1AcamLR0d25+5LOlBPw7RERNxyDr0tsO+0rzMr/uwnhW6MmQhMBIiMjLygjXUIC6ZvZFNmXBtNh7DgC3oMERFfVKuHttba+dbaeGttfHj4hb03Z1RYMG9NGKAyFxE5gzsKfT/Q7rSvIyr+TEREapE7Cn0ZcLspdxGQV1Pnz0VE5Nyqctniu8BQIMwYkwlMBwIArLXzgA8pv2QxnfLLFu+qqbAiInJuVbnK5ZZKllvgQbclEhGRC6Lr/UREfIQKXUTER6jQRUR8hApdRMRHmPLXNB3YsDHZwJ4L/OthwBE3xvEG2mf/oH32D9XZ5/bW2rPemelYoVeHMWajtTbe6Ry1SfvsH7TP/qGm9lmnXEREfIQKXUTER3hroc93OoADtM/+QfvsH2pkn73yHLqIiPyUtx6hi4jIGVToIiI+wqML3RgzwhizzRiTboyZcpbl9Y0x/6pY/k0lb5XnFaqwz783xqQZY5KMMZ8ZY9o7kdOdKtvn09YbZ4yxxhivv8StKvtsjPllxXOdaoz5Z21ndLcqfG9HGmNWG2N+qPj+HuVETncxxiwwxmQZY1LOsdwYY/5a8e+RZIzpW+2NWms98gOoC+wEOgKBwGag5xnr/BqYV/H5zcC/nM5dC/t8OdCw4vMH/GGfK9YLAdYAG4B4p3PXwvPcBfgBaFrxdQunc9fCPs8HHqj4vCew2+nc1dzny4C+QMo5lo8CPgIMcBHwTXW36clH6AOAdGtthrW2GHiP8jekPt0Y4K2KzxcDw40xphYzulul+2ytXW2tLaz4cgPl7xDlzaryPAPMBJ4BimozXA2pyj7fC7xsrT0KYK3NquWM7laVfbZA44rPQ4EDtZjP7ay1a4Dcn1llDLDQltsANDHGtK7ONj250M/15tNnXcdaWwrkAc1rJV3NqMo+n+5uyv8P780q3eeKX0XbWWtX1GawGlSV57kr0NUY87UxZoMxZkStpasZVdnnGcBtFW+k8yHwUO1Ec8z5/rxXqtI3uBDPZIy5DYgHhjidpSYZY+oAfwbudDhKbatH+WmXoZT/FrbGGBNrrT3mZKgadgvwprX2OWPMIOAfxpgYa63L6WDewpOP0Kvy5tP/XccYU4/yX9NyaiVdzajSG24bY64ApgHXWmtP1VK2mlLZPocAMcAXxpjdlJ9rXOblL4xW5XnOBJZZa0ustbuA7ZQXvLeqyj7fDfwbwFq7HgiifIiVr6rSz/v58ORC/w7oYozpYIwJpPxFz2VnrLMMuKPi8xuAz23Fqw1eqtJ9Nsb0Af5GeZl7+3lVqGSfrbV51towa22UtTaK8tcNrrXWbnQmrltU5Xt7KeVH5xhjwig/BZNRixndrSr7vBcYDmCM6UF5oWfXasratQy4veJql4uAPGvtwWo9otOvBFfyKvEoyo9MdgLTKv7sScp/oKH8CV9E+RtUfwt0dDpzLezzp8Bh4MeKj2VOZ67pfT5j3S/w8qtcqvg8G8pPNaUBycDNTmeuhX3uCXxN+RUwPwJXOp25mvv7LnAQKKH8N667gfuB+097jl+u+PdIdsf3tW79FxHxEZ58ykVERM6DCl1ExEeo0EVEfIQKXUTER6jQRUR8hApdRMRHqNBFRHzE/wHCD3n6YSm6cAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from IPython.utils import capture\n",
+    "from IPython.display import Image, display\n",
+    "\n",
+    "with capture.capture_output() as cap:\n",
+    "    \n",
+    "    df = pd.DataFrame(data={\"col1\": [1, 2]})\n",
+    "    display(Image(df.plot(kind=\"line\", subplots=True, sharex=True, legend=True)))\n",
+    "assert len(cap.outputs[0].data) == 2\n",
+    "assert \"IPython.core.display.Image\" in cap.outputs[0].data[\"text/plain\"]\n",
+    "assert len(cap.outputs[0].data[\"image/png\"]) > 0 #assert an image actually exists"
+   ]
+  }
+ ],
+ "metadata": {
+  "file_extension": ".py",
+  "kernelspec": {
+   "display_name": "Python 3.9.9 64-bit ('venv': venv)",
+   "language": "python",
+   "name": "python39964bitvenvvenv9a8385474b4d41148e4fbaedabba2862"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  },
+  "mimetype": "text/x-python",
+  "name": "python",
+  "npconvert_exporter": "python",
+  "pygments_lexer": "ipython3",
+  "version": 3
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
As described in the issues https://github.com/ydataai/pandas-profiling/issues/888 and https://github.com/ydataai/pandas-profiling/issues/837 , upon the release of 3.1.0, a side effect of importing pandas_profiling was that it overrode the existing backend of matplotlib on import, and prevented plots from being rendered in Jupyter environments.

Since it seems the backend does not needed to be set per [matplots documentation](https://matplotlib.org/3.2.1/tutorials/introductory/usage.html#the-builtin-backends),

By default, Matplotlib should automatically select a default backend which allows both interactive work and plotting from scripts, with output to the screen and/or to a file, so at least initially you will not need to worry about the backend.

Using matplot.libuse() will require changes in your code if users want to use a different backend. Therefore, you should avoid explicitly calling use unless absolutely necessary.

and it is generally a best practice to not have side effects upon importing a package, I have elected to remove that line.

A new test is in place in notebooks/notebook_plotting.ipynb to prevent this in the future.