### PR TITLE
feat: add 3.11.x compatibility

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: self-hosted
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -24,7 +24,7 @@ jobs:
         echo "sonar.projectKey=${{ github.event.repository.name }}" > sonar-project.properties
 
     - name: SonarQube Scan
-      uses: sonarsource/sonarqube-scan-action@v1.1.0
+      uses: sonarsource/sonarqube-scan-action@v1.2.0
       env:
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}

--- a/docsrc/source/pages/reference/changelog.rst
+++ b/docsrc/source/pages/reference/changelog.rst
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+.. include:: changelog/v3_6_2.md
+   :parser: myst_parser.sphinx_
+
 .. include:: changelog/v3_6_1.md
    :parser: myst_parser.sphinx_
 

--- a/docsrc/source/pages/reference/changelog/v3_6_2.md
+++ b/docsrc/source/pages/reference/changelog/v3_6_2.md
@@ -1,0 +1,9 @@
+### Changelog v3.6.2
+
+
+#### 🐛 Bug fixes
+
+* comparison alerts ([#1229](https://github.com/ydataai/pandas-profiling/issues/1229)) ([bbca61b](https://github.com/ydataai/pandas-profiling/commit/bbca61b0b5e109563aee88a245d6b776d1b65d9b))
+* comparison histogram ([#1228](https://github.com/ydataai/pandas-profiling/issues/1228)) ([0081581](https://github.com/ydataai/pandas-profiling/commit/0081581c67d0667ad869677a5b9b29d276d5a461))
+* comparison report style issues ([a465cdd](https://github.com/ydataai/pandas-profiling/commit/a465cddc88091ed99485b7e34d4c037faf37f6d3))
+* update the link for the people-example.csv ([2bb5043](https://github.com/ydataai/pandas-profiling/commit/2bb5043fd147a289cfe54a9feddcb9693275e13d))

--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -4,6 +4,7 @@ from typing import Any, List, Optional, Tuple, Union
 import pandas as pd
 
 from pandas_profiling.config import Correlation, Settings
+from pandas_profiling.model.alerts import Alert
 from pandas_profiling.profile_report import ProfileReport
 
 
@@ -220,17 +221,17 @@ def _apply_config(description: dict, config: Settings) -> dict:
     return description
 
 
-def _is_alert_present(alert, alert_list):
-    for a in alert_list:
-        if a.column_name == alert.column_name and a.alert_type == alert.alert_type:
-            return True
-    return False
+def _is_alert_present(alert: Alert, alert_list: list) -> bool:
+    return any(
+        a.column_name == alert.column_name and a.alert_type == alert.alert_type
+        for a in alert_list
+    )
 
 
 def _create_placehoder_alerts(report_alerts: tuple) -> tuple:
     from copy import copy
 
-    fixed = [[] for _ in report_alerts]
+    fixed: list = [[] for _ in report_alerts]
     for idx, alerts in enumerate(report_alerts):
         for alert in alerts:
             fixed[idx].append(alert)

--- a/src/pandas_profiling/compare_reports.py
+++ b/src/pandas_profiling/compare_reports.py
@@ -220,6 +220,30 @@ def _apply_config(description: dict, config: Settings) -> dict:
     return description
 
 
+def _is_alert_present(alert, alert_list):
+    for a in alert_list:
+        if a.column_name == alert.column_name and a.alert_type == alert.alert_type:
+            return True
+    return False
+
+
+def _create_placehoder_alerts(report_alerts: tuple) -> tuple:
+    from copy import copy
+
+    fixed = [[] for _ in report_alerts]
+    for idx, alerts in enumerate(report_alerts):
+        for alert in alerts:
+            fixed[idx].append(alert)
+            for i, fix in enumerate(fixed):
+                if i == idx:
+                    continue
+                if not _is_alert_present(alert, report_alerts[i]):
+                    empty_alert = copy(alert)
+                    empty_alert._is_empty = True
+                    fix.append(empty_alert)
+    return tuple(fixed)
+
+
 def compare(
     reports: List[ProfileReport],
     config: Optional[Settings] = None,
@@ -279,7 +303,7 @@ def compare(
         res = _update_merge(res, r)
 
     res["analysis"]["title"] = _compare_title(res["analysis"]["title"])
-
+    res["alerts"] = _create_placehoder_alerts(res["alerts"])
     profile = ProfileReport(None, config=_config)
     profile._description_set = res
     return profile

--- a/src/pandas_profiling/model/alerts.py
+++ b/src/pandas_profiling/model/alerts.py
@@ -80,6 +80,7 @@ class Alert:
         values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         fields: Optional[Set] = None,
+        is_empty: bool = False,
     ):
         if values is None:
             values = {}
@@ -90,6 +91,7 @@ class Alert:
         self.alert_type = alert_type
         self.values = values
         self.column_name = column_name
+        self._is_empty = is_empty
 
     @property
     def alert_type_name(self) -> str:

--- a/src/pandas_profiling/model/correlations.py
+++ b/src/pandas_profiling/model/correlations.py
@@ -12,7 +12,10 @@ from pandas_profiling.utils.compat import pandas_version_info
 if pandas_version_info() >= (1, 5):
     from pandas.errors import DataError
 else:
-    from pandas.core.base import DataError
+    try:
+        from pandas.core.base import DataError
+    except:
+        from pandas.errors import DataError
 
 
 class Correlation:

--- a/src/pandas_profiling/report/presentation/flavours/html/templates/alerts.html
+++ b/src/pandas_profiling/report/presentation/flavours/html/templates/alerts.html
@@ -16,7 +16,7 @@
                     <tr{% if loop.first %} style="border-top:0"{% endif %}>
                         {% for alert in value %}
                             <td>
-                                {% if alert is not none %}
+                                {% if not alert._is_empty %}
                                     {% include 'alerts/alert_' + alert.alert_type.name | lower  + '.html'  %}
                                 {% else %}
                                     <em>Alert not present in {{ style._labels[idx] }}</em>

--- a/src/pandas_profiling/visualisation/plot.py
+++ b/src/pandas_profiling/visualisation/plot.py
@@ -31,7 +31,6 @@ def _plot_histogram(
     figsize: tuple = (6, 4),
     date: bool = False,
     hide_yaxis: bool = False,
-    vertically: bool = True,
 ) -> plt.Figure:
     """Plot a histogram from the data and return the AxesSubplot object.
 
@@ -41,7 +40,6 @@ def _plot_histogram(
         bins: number of bins (int for equal size, ndarray for variable size)
         figsize: The size of the figure (width, height) in inches, default (6,4)
         date: is the x-axis of date type
-        vertically: display the histograms vertically if true, and horizontally otherwhise
 
     Returns:
         The histogram plot.
@@ -49,24 +47,17 @@ def _plot_histogram(
     # we have precomputed the histograms...
     if isinstance(bins, list):
         n_labels = len(config.html.style._labels)
-        if vertically:
-            fig, ax = plt.subplots(
-                nrows=n_labels, ncols=1, sharex=True, sharey=True, figsize=figsize
-            )
-        else:
-            fig, ax = plt.subplots(
-                nrows=1, ncols=n_labels, sharex=True, sharey=True, figsize=figsize
-            )
+        fig = plt.figure(figsize=figsize)
+        plot = fig.add_subplot(111)
 
-        for idx in range(n_labels):
-            plot = ax[idx]
-
+        for idx in reversed(list(range(n_labels))):
             diff = np.diff(bins[idx])
             plot.bar(
                 bins[idx][:-1] + diff / 2,  # type: ignore
                 series[idx],
                 diff,
                 facecolor=config.html.style.primary_colors[idx],
+                alpha=0.6,
             )
 
             if date:
@@ -127,9 +118,7 @@ def histogram(
       The resulting histogram encoded as a string.
 
     """
-    plot = _plot_histogram(
-        config, series, bins, date=date, figsize=(7, 3), vertically=False
-    )
+    plot = _plot_histogram(config, series, bins, date=date, figsize=(7, 3))
     plot.xaxis.set_tick_params(rotation=90 if date else 45)
     plot.figure.tight_layout()
     return plot_360_n0sc0pe(config)

--- a/tests/unit/test_decorator.py
+++ b/tests/unit/test_decorator.py
@@ -6,7 +6,7 @@ from pandas_profiling import ProfileReport
 def test_decorator(get_data_file):
     people_example = get_data_file(
         "people_example.csv",
-        "https://raw.githubusercontent.com/oncletom/coursera-ml/master/week-1/people-example.csv",
+        "https://raw.githubusercontent.com/ydataai/coursera-ml/master/week-1/people-example.csv",
     )
     df = pd.read_csv(people_example)
     report = ProfileReport(


### PR DESCRIPTION
attempt to fix cannot import name 'DataError' from 'pandas.core.base'

- successfully able to run from pandas.errors import DataError in Python 3.11.x
- used try/except to avoid introducing issues for other Python ver

revised from: #1239 