### PR TITLE
fix: correlation between columns w/o non-null row

### DIFF
--- a/src/ydata_profiling/model/pandas/correlations_pandas.py
+++ b/src/ydata_profiling/model/pandas/correlations_pandas.py
@@ -53,6 +53,10 @@ def _cramers_corrected_stat(confusion_matrix: pd.DataFrame, correction: bool) ->
     Returns:
         The Cramer's V corrected stat for the two variables.
     """
+    # handles empty crosstab
+    if confusion_matrix.empty:
+        return 0
+
     chi2 = stats.chi2_contingency(confusion_matrix, correction=correction)[0]
     n = confusion_matrix.sum().sum()
     phi2 = chi2 / n


### PR DESCRIPTION
Fixes an error when calculating the correlation between columns where there is no nonnull simultaneously for both columns, i.e.
 when column A is non-null column B is null and vice versa.