### PR TITLE
fix: comparing issues when pyspark is installed and when the report summaries are used

### DIFF
--- a/src/ydata_profiling/profile_report.py
+++ b/src/ydata_profiling/profile_report.py
@@ -151,7 +151,7 @@ class ProfileReport(SerializeReport, ExpectationsReport):
 
     @staticmethod
     def __validate_inputs(
-        df: Union[pd.DataFrame, sDataFrame],
+        df: Optional[Union[pd.DataFrame, sDataFrame]],
         minimal: bool,
         tsmode: bool,
         config_file: Optional[Union[Path, str]],
@@ -188,8 +188,8 @@ class ProfileReport(SerializeReport, ExpectationsReport):
 
     @staticmethod
     def __initialize_dataframe(
-        df: Union[pd.DataFrame, sDataFrame], report_config: Settings
-    ) -> Union[pd.DataFrame, sDataFrame]:
+        df: Optional[Union[pd.DataFrame, sDataFrame]], report_config: Settings
+    ) -> Optional[Union[pd.DataFrame, sDataFrame]]:
         if (
             df is not None
             and isinstance(df, pd.DataFrame)

--- a/tests/unit/test_comparison.py
+++ b/tests/unit/test_comparison.py
@@ -29,8 +29,24 @@ def test_compare_two(reports):
     assert len(result_description["table"]["n"]) == 2
 
 
+def test_compare_two_description(reports):
+    args = [r.get_description() for r in reports[:2]]
+    assert len(args) == 2
+    result = compare(args)
+    result_description = result.get_description()
+    assert len(result_description["table"]["n"]) == 2
+
+
 def test_compare_three(reports):
     args = reports[:3]
+    assert len(args) == 3
+    result = compare(args)
+    result_description = result.get_description()
+    assert len(result_description["table"]["n"]) == 3
+
+
+def test_compare_three_description(reports):
+    args = [r.get_description() for r in reports[:3]]
     assert len(args) == 3
     result = compare(args)
     result_description = result.get_description()


### PR DESCRIPTION
This PR solves two issues:
- When PySpark is installed, the ProfileReport was not prepared to be instantiated without a DataFrame. This only worked when PySpark was not installed because the `sDataFrame` `TypeVar` assumed None when the PySpark DataFrame import failed. The ProfileReport can now be instantiated without DataFrames in both scenarios.
- The comparison between reports failed when the summary of the reports (obtained through the `get_description` method) was used. The validations and preprocessing steps of the `compare` method were not prepared to work with these summaries, and the code assumed only ProfileReport objects were used. The comparison now works with both ProfileReport objects and report summaries (i.e., dictionaries).