### PR TITLE
fix: complete alerts information in json

### DIFF
--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -27,7 +27,6 @@ def fmt_percent(value: float, edge_cases: bool = True) -> str:
 
     return f"{value*100:2.1f}%"
 
-
 @unique
 class AlertType(Enum):
     """Alert types"""

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -27,6 +27,7 @@ def fmt_percent(value: float, edge_cases: bool = True) -> str:
 
     return f"{value*100:2.1f}%"
 
+
 @unique
 class AlertType(Enum):
     """Alert types"""
@@ -373,6 +374,7 @@ class SkewedAlert(Alert):
             return description + f"(\u03b31 = {self.values['skewness']})"
         else:
             return description
+
 
 
 class TypeDateAlert(Alert):

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -95,14 +95,14 @@ class Alert:
     def __init__(
         self,
         alert_type: AlertType,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
-        fields: Optional[Set] = set(),
+        fields: Optional[Set] = None,
         is_empty: bool = False,
     ):
-        self.fields = fields
+        self.fields = fields or set()
         self.alert_type = alert_type
-        self.values = values
+        self.values = values or {}
         self.column_name = column_name
         self._is_empty = is_empty
 
@@ -143,7 +143,7 @@ class Alert:
 class ConstantLengthAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -162,7 +162,7 @@ class ConstantLengthAlert(Alert):
 class ConstantAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -181,7 +181,7 @@ class ConstantAlert(Alert):
 class DuplicatesAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -203,7 +203,7 @@ class DuplicatesAlert(Alert):
 class EmptyAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -218,7 +218,7 @@ class EmptyAlert(Alert):
 class HighCardinalityAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -240,7 +240,7 @@ class HighCardinalityAlert(Alert):
 class HighCorrelationAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -263,7 +263,7 @@ class HighCorrelationAlert(Alert):
 class ImbalanceAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -286,7 +286,7 @@ class ImbalanceAlert(Alert):
 class InfiniteAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -308,7 +308,7 @@ class InfiniteAlert(Alert):
 class MissingAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -330,7 +330,7 @@ class MissingAlert(Alert):
 class NonStationaryAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -343,7 +343,7 @@ class NonStationaryAlert(Alert):
 class SeasonalAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -356,7 +356,7 @@ class SeasonalAlert(Alert):
 class SkewedAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -379,7 +379,7 @@ class SkewedAlert(Alert):
 class TypeDateAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -392,7 +392,7 @@ class TypeDateAlert(Alert):
 class UniformAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -405,7 +405,7 @@ class UniformAlert(Alert):
 class UniqueAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -424,7 +424,7 @@ class UniqueAlert(Alert):
 class UnsupportedAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -437,7 +437,7 @@ class UnsupportedAlert(Alert):
 class ZerosAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
@@ -459,7 +459,7 @@ class ZerosAlert(Alert):
 class RejectedAlert(Alert):
     def __init__(
         self,
-        values: Optional[Dict] = {},
+        values: Optional[Dict] = None,
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -376,7 +376,6 @@ class SkewedAlert(Alert):
             return description
 
 
-
 class TypeDateAlert(Alert):
     def __init__(
         self,

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -148,9 +148,9 @@ class ConstantLengthAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.CONSTANT_LENGTH,
-            values,
-            column_name,
+            alert_type=AlertType.CONSTANT_LENGTH,
+            values=values,
+            column_name=column_name,
             fields={"composition_min_length", "composition_max_length"},
             is_empty=is_empty,
         )
@@ -167,9 +167,9 @@ class ConstantAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.CONSTANT,
-            values,
-            column_name,
+            alert_type=AlertType.CONSTANT,
+            values=values,
+            column_name=column_name,
             fields={"n_distinct"},
             is_empty=is_empty,
         )
@@ -186,9 +186,9 @@ class DuplicatesAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.DUPLICATES,
-            values,
-            column_name,
+            alert_type=AlertType.DUPLICATES,
+            values=values,
+            column_name=column_name,
             fields={"n_duplicates"},
             is_empty=is_empty,
         )
@@ -208,7 +208,11 @@ class EmptyAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.EMPTY, values, column_name, fields={"n"}, is_empty=is_empty
+            alert_type=AlertType.EMPTY,
+            values=values,
+            column_name=column_name,
+            fields={"n"},
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -223,9 +227,9 @@ class HighCardinalityAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.HIGH_CARDINALITY,
-            values,
-            column_name,
+            alert_type=AlertType.HIGH_CARDINALITY,
+            values=values,
+            column_name=column_name,
             fields={"n_distinct"},
             is_empty=is_empty,
         )
@@ -245,7 +249,10 @@ class HighCorrelationAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.HIGH_CORRELATION, values, column_name, set(), is_empty
+            alert_type=AlertType.HIGH_CORRELATION,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -268,9 +275,9 @@ class ImbalanceAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.IMBALANCE,
-            values,
-            column_name,
+            alert_type=AlertType.IMBALANCE,
+            values=values,
+            column_name=column_name,
             fields={"imbalance"},
             is_empty=is_empty,
         )
@@ -291,9 +298,9 @@ class InfiniteAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.INFINITE,
-            values,
-            column_name,
+            alert_type=AlertType.INFINITE,
+            values=values,
+            column_name=column_name,
             fields={"p_infinite", "n_infinite"},
             is_empty=is_empty,
         )
@@ -313,9 +320,9 @@ class MissingAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.MISSING,
-            values,
-            column_name,
+            alert_type=AlertType.MISSING,
+            values=values,
+            column_name=column_name,
             fields={"p_missing", "n_missing"},
             is_empty=is_empty,
         )
@@ -334,7 +341,12 @@ class NonStationaryAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.NON_STATIONARY, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.NON_STATIONARY,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is non stationary"
@@ -347,7 +359,12 @@ class SeasonalAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.SEASONAL, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.SEASONAL,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is seasonal"
@@ -361,9 +378,9 @@ class SkewedAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.SKEWED,
-            values,
-            column_name,
+            alert_type=AlertType.SKEWED,
+            values=values,
+            column_name=column_name,
             fields={"skewness"},
             is_empty=is_empty,
         )
@@ -383,7 +400,12 @@ class TypeDateAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.TYPE_DATE, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.TYPE_DATE,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] only contains datetime values, but is categorical. Consider applying `pd.to_datetime()`"
@@ -396,7 +418,12 @@ class UniformAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.UNIFORM, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.UNIFORM,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is uniformly distributed"
@@ -410,9 +437,9 @@ class UniqueAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.UNIQUE,
-            values,
-            column_name,
+            alert_type=AlertType.UNIQUE,
+            values=values,
+            column_name=column_name,
             fields={"n_distinct", "p_distinct", "n_unique", "p_unique"},
             is_empty=is_empty,
         )
@@ -428,7 +455,12 @@ class UnsupportedAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.UNSUPPORTED, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.UNSUPPORTED,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is an unsupported type, check if it needs cleaning or further analysis"
@@ -442,9 +474,9 @@ class ZerosAlert(Alert):
         is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.ZEROS,
-            values,
-            column_name,
+            alert_type=AlertType.ZEROS,
+            values=values,
+            column_name=column_name,
             fields={"n_zeros", "p_zeros"},
             is_empty=is_empty,
         )
@@ -463,7 +495,12 @@ class RejectedAlert(Alert):
         column_name: Optional[str] = None,
         is_empty: bool = False,
     ):
-        super().__init__(AlertType.REJECTED, values, column_name, set(), is_empty)
+        super().__init__(
+            alert_type=AlertType.REJECTED,
+            values=values,
+            column_name=column_name,
+            is_empty=is_empty,
+        )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] was rejected"


### PR DESCRIPTION
Add to render_json the same information available in the HTML for alerts.
previously:
```
"alerts": [
    "[HIGH_CORRELATION] alert on column ascending_sequence",
    "[HIGH_CORRELATION] alert on column descending_sequence_with_noise",
    "[ZEROS] alert on column zeros"
]
```
now:
```
"alerts": [
    "[ascending_sequence] is highly overall correlated with [descending_sequence_with_noise]",
    "[descending_sequence_with_noise] is highly overall correlated with [ascending_sequence]",
    "[zeros] has 1000 (100.0%) zeros"
],
```
Fixes https://github.com/ydataai/ydata-profiling/issues/1301