### PR TITLE
fix: json ignoring redact

### DIFF
--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -10,6 +10,23 @@ from ydata_profiling.config import Settings
 from ydata_profiling.model.correlations import perform_check_correlation
 
 
+def fmt_percent(value: float, edge_cases: bool = True) -> str:
+    """Format a ratio as a percentage.
+
+    Args:
+        edge_cases: Check for edge cases?
+        value: The ratio.
+
+    Returns:
+        The percentage with 1 point precision.
+    """
+    if edge_cases and round(value, 3) == 0 and value > 0:
+        return "< 0.1%"
+    if edge_cases and round(value, 3) == 1 and value < 1:
+        return "> 99.9%"
+
+    return f"{value*100:2.1f}%"
+
 @unique
 class AlertType(Enum):
     """Alert types"""
@@ -77,16 +94,11 @@ class Alert:
     def __init__(
         self,
         alert_type: AlertType,
-        values: Optional[Dict] = None,
+        values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        fields: Optional[Set] = None,
+        fields: Optional[Set] = set(),
         is_empty: bool = False,
     ):
-        if values is None:
-            values = {}
-        if fields is None:
-            fields = set()
-
         self.fields = fields
         self.alert_type = alert_type
         self.values = values
@@ -113,10 +125,346 @@ class Alert:
             name = f'<abbr title="This variable has a high {corr} correlation with {num} fields: {title}">HIGH CORRELATION</abbr>'
         return name
 
-    def __repr__(self):
+    def _get_description(self) -> str:
+        """Return a human level description of the alert.
+
+        Returns:
+            str: alert description
+        """
         alert_type = self.alert_type.name
         column = self.column_name
         return f"[{alert_type}] alert on column {column}"
+
+    def __repr__(self):
+        return self._get_description()
+
+
+class ConstantLengthAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.CONSTANT_LENGTH,
+            values, column_name,
+            fields={"composition_min_length", "composition_max_length"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has a constant length"
+
+
+class ConstantAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.CONSTANT,
+            values,
+            column_name,
+            fields={"n_distinct"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has a constant value"
+
+
+class DuplicatesAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.DUPLICATES,
+            values, column_name,
+            fields={"n_duplicates"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"Dataset has {self.values['n_duplicates']} ({fmt_percent(self.values['p_duplicates'])}) duplicate rows"
+
+
+class EmptyAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.EMPTY,
+            values, column_name,
+            fields={"n"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return "Dataset is empty"
+
+
+class HighCardinalityAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.HIGH_CARDINALITY,
+            values, column_name,
+            fields={"n_distinct"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has {self.values['n_distinct']:} ({fmt_percent(self.values['p_distinct'])}) distinct values"
+
+
+class HighCorrelationAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.HIGH_CORRELATION,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        description = f"[{self.column_name}] is highly {self.values['corr']} correlated with [{self.values['fields'][0]}]"
+        if len(self.values["fields"]) > 1:
+            description += f" and {len(self.values['fields']) - 1} other fields"
+        return description
+
+
+class ImbalanceAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.IMBALANCE,
+            values, column_name,
+            fields={"imbalance"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is highly imbalanced ({self.values['imbalance']})"
+
+
+class InfiniteAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.INFINITE,
+            values, column_name,
+            fields={"p_infinite", "n_infinite"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has {self.values['n_infinite']} ({fmt_percent(self.values['p_infinite'])}) infinite values"
+
+
+class MissingAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.MISSING,
+            values, column_name,
+            fields={"p_missing", "n_missing"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] {self.values['n_missing']} ({fmt_percent(self.values['p_missing'])}) missing values"
+
+
+class NonStationaryAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.NON_STATIONARY,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is non stationary"
+
+
+class SeasonalAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.SEASONAL,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is seasonal"
+
+
+class SkewedAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.SKEWED,
+            values, column_name,
+            fields={"skewness"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is highly skewed (\u03b31 = {self.values['skewness']})"
+
+class TypeDateAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.TYPE_DATE,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] only contains datetime values, but is categorical. Consider applying `pd.to_datetime()`"
+
+
+class UniformAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.UNIFORM,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is uniformly distributed"
+
+
+class UniqueAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.UNIQUE,
+            values,
+            column_name,
+            fields={"n_distinct", "p_distinct", "n_unique", "p_unique"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has unique values"
+
+
+class UnsupportedAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.UNSUPPORTED,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] is an unsupported type, check if it needs cleaning or further analysis"
+
+
+class ZerosAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.ZEROS,
+            values, column_name,
+            fields={"n_zeros", "p_zeros"},
+            is_empty=is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] has {self.values['n_zeros']} ({fmt_percent(self.values['p_zeros'])}) zeros"
+
+
+class RejectedAlert(Alert):
+    def __init__(
+        self,
+        values: Optional[Dict] = {},
+        column_name: Optional[str] = None,
+        is_empty: bool = False
+    ):
+        super().__init__(
+            AlertType.REJECTED,
+            values, column_name,
+            set(),
+            is_empty
+        )
+
+    def _get_description(self) -> str:
+        return f"[{self.column_name}] was rejected"
 
 
 def check_table_alerts(table: dict) -> List[Alert]:
@@ -131,18 +479,14 @@ def check_table_alerts(table: dict) -> List[Alert]:
     alerts = []
     if alert_value(table.get("n_duplicates", np.nan)):
         alerts.append(
-            Alert(
-                alert_type=AlertType.DUPLICATES,
+            DuplicatesAlert(
                 values=table,
-                fields={"n_duplicates"},
             )
         )
     if table["n"] == 0:
         alerts.append(
-            Alert(
-                alert_type=AlertType.EMPTY,
+            EmptyAlert(
                 values=table,
-                fields={"n"},
             )
         )
     return alerts
@@ -153,36 +497,21 @@ def numeric_alerts(config: Settings, summary: dict) -> List[Alert]:
 
     # Skewness
     if skewness_alert(summary["skewness"], config.vars.num.skewness_threshold):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.SKEWED,
-                fields={"skewness"},
-            )
-        )
+        alerts.append(SkewedAlert(summary))
 
     # Infinite values
     if alert_value(summary["p_infinite"]):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.INFINITE,
-                fields={"p_infinite", "n_infinite"},
-            )
-        )
+        alerts.append(InfiniteAlert(summary))
 
     # Zeros
     if alert_value(summary["p_zeros"]):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.ZEROS,
-                fields={"n_zeros", "p_zeros"},
-            )
-        )
+        alerts.append(ZerosAlert(summary))
 
     if (
         "chi_squared" in summary
         and summary["chi_squared"]["pvalue"] > config.vars.num.chi_squared_threshold
     ):
-        alerts.append(Alert(alert_type=AlertType.UNIFORM))
+        alerts.append(UniformAlert())
 
     return alerts
 
@@ -191,10 +520,10 @@ def timeseries_alerts(config: Settings, summary: dict) -> List[Alert]:
     alerts = numeric_alerts(config, summary)
 
     if not summary["stationary"]:
-        alerts.append(Alert(alert_type=AlertType.NON_STATIONARY))
+        alerts.append(NonStationaryAlert())
 
     if summary["seasonal"]:
-        alerts.append(Alert(alert_type=AlertType.SEASONAL))
+        alerts.append(SeasonalAlert())
 
     return alerts
 
@@ -204,58 +533,38 @@ def categorical_alerts(config: Settings, summary: dict) -> List[Alert]:
 
     # High cardinality
     if summary.get("n_distinct", np.nan) > config.vars.cat.cardinality_threshold:
-        alerts.append(
-            Alert(
-                alert_type=AlertType.HIGH_CARDINALITY,
-                fields={"n_distinct"},
-            )
-        )
+        alerts.append(HighCardinalityAlert(summary))
 
     if (
         "chi_squared" in summary
         and summary["chi_squared"]["pvalue"] > config.vars.cat.chi_squared_threshold
     ):
-        alerts.append(Alert(alert_type=AlertType.UNIFORM))
+        alerts.append()
 
     if summary.get("date_warning"):
-        alerts.append(Alert(alert_type=AlertType.TYPE_DATE))
+        alerts.append()
 
     # Constant length
     if "composition" in summary and summary["min_length"] == summary["max_length"]:
-        alerts.append(
-            Alert(
-                alert_type=AlertType.CONSTANT_LENGTH,
-                fields={"composition_min_length", "composition_max_length"},
-            )
-        )
+        alerts.append(ConstantLengthAlert())
 
     # Imbalance
     if (
         "imbalance" in summary
         and summary["imbalance"] > config.vars.cat.imbalance_threshold
     ):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.IMBALANCE,
-                fields={"imbalance"},
-            )
-        )
+        alerts.append(ImbalanceAlert(summary))
     return alerts
 
 
 def boolean_alerts(config: Settings, summary: dict) -> List[Alert]:
     alerts = []
-    # Imbalance
+
     if (
         "imbalance" in summary
         and summary["imbalance"] > config.vars.bool.imbalance_threshold
     ):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.IMBALANCE,
-                fields={"imbalance"},
-            )
-        )
+        alerts.append(ImbalanceAlert())
     return alerts
 
 
@@ -264,12 +573,7 @@ def generic_alerts(summary: dict) -> List[Alert]:
 
     # Missing
     if alert_value(summary["p_missing"]):
-        alerts.append(
-            Alert(
-                alert_type=AlertType.MISSING,
-                fields={"p_missing", "n_missing"},
-            )
-        )
+        alerts.append(MissingAlert())
 
     return alerts
 
@@ -278,32 +582,16 @@ def supported_alerts(summary: dict) -> List[Alert]:
     alerts = []
 
     if summary.get("n_distinct", np.nan) == summary["n"]:
-        alerts.append(
-            Alert(
-                alert_type=AlertType.UNIQUE,
-                fields={"n_distinct", "p_distinct", "n_unique", "p_unique"},
-            )
-        )
+        alerts.append(UniqueAlert())
     if summary.get("n_distinct", np.nan) == 1:
-        alerts.append(
-            Alert(
-                alert_type=AlertType.CONSTANT,
-                fields={"n_distinct"},
-            )
-        )
+        alerts.append(ConstantAlert(summary))
     return alerts
 
 
 def unsupported_alerts(summary: Dict[str, Any]) -> List[Alert]:
     alerts = [
-        Alert(
-            alert_type=AlertType.UNSUPPORTED,
-            fields=set(),
-        ),
-        Alert(
-            alert_type=AlertType.REJECTED,
-            fields=set(),
-        ),
+        UnsupportedAlert(),
+        RejectedAlert(),
     ]
     return alerts
 
@@ -357,9 +645,8 @@ def check_correlation_alerts(config: Settings, correlations: dict) -> List[Alert
     if len(correlations_consolidated) > 0:
         for col, fields in correlations_consolidated.items():
             alerts.append(
-                Alert(
+                HighCorrelationAlert(
                     column_name=col,
-                    alert_type=AlertType.HIGH_CORRELATION,
                     values={"corr": "overall", "fields": fields},
                 )
             )

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -513,10 +513,10 @@ def categorical_alerts(config: Settings, summary: dict) -> List[Alert]:
         "chi_squared" in summary
         and summary["chi_squared"]["pvalue"] > config.vars.cat.chi_squared_threshold
     ):
-        alerts.append()
+        alerts.append(UniformAlert())
 
     if summary.get("date_warning"):
-        alerts.append()
+        alerts.append(TypeDateAlert())
 
     # Constant length
     if "composition" in summary and summary["min_length"] == summary["max_length"]:

--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -27,6 +27,7 @@ def fmt_percent(value: float, edge_cases: bool = True) -> str:
 
     return f"{value*100:2.1f}%"
 
+
 @unique
 class AlertType(Enum):
     """Alert types"""
@@ -144,13 +145,14 @@ class ConstantLengthAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.CONSTANT_LENGTH,
-            values, column_name,
+            values,
+            column_name,
             fields={"composition_min_length", "composition_max_length"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -162,14 +164,14 @@ class ConstantAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.CONSTANT,
             values,
             column_name,
             fields={"n_distinct"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -181,13 +183,14 @@ class DuplicatesAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.DUPLICATES,
-            values, column_name,
+            values,
+            column_name,
             fields={"n_duplicates"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -199,13 +202,10 @@ class EmptyAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.EMPTY,
-            values, column_name,
-            fields={"n"},
-            is_empty=is_empty
+            AlertType.EMPTY, values, column_name, fields={"n"}, is_empty=is_empty
         )
 
     def _get_description(self) -> str:
@@ -217,13 +217,14 @@ class HighCardinalityAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.HIGH_CARDINALITY,
-            values, column_name,
+            values,
+            column_name,
             fields={"n_distinct"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -235,13 +236,10 @@ class HighCorrelationAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
-            AlertType.HIGH_CORRELATION,
-            values, column_name,
-            set(),
-            is_empty
+            AlertType.HIGH_CORRELATION, values, column_name, set(), is_empty
         )
 
     def _get_description(self) -> str:
@@ -256,13 +254,14 @@ class ImbalanceAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.IMBALANCE,
-            values, column_name,
+            values,
+            column_name,
             fields={"imbalance"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -274,13 +273,14 @@ class InfiniteAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.INFINITE,
-            values, column_name,
+            values,
+            column_name,
             fields={"p_infinite", "n_infinite"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -292,13 +292,14 @@ class MissingAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.MISSING,
-            values, column_name,
+            values,
+            column_name,
             fields={"p_missing", "n_missing"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -310,14 +311,9 @@ class NonStationaryAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.NON_STATIONARY,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.NON_STATIONARY, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is non stationary"
@@ -328,14 +324,9 @@ class SeasonalAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.SEASONAL,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.SEASONAL, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is seasonal"
@@ -346,31 +337,28 @@ class SkewedAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.SKEWED,
-            values, column_name,
+            values,
+            column_name,
             fields={"skewness"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is highly skewed (\u03b31 = {self.values['skewness']})"
+
 
 class TypeDateAlert(Alert):
     def __init__(
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.TYPE_DATE,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.TYPE_DATE, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] only contains datetime values, but is categorical. Consider applying `pd.to_datetime()`"
@@ -381,14 +369,9 @@ class UniformAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.UNIFORM,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.UNIFORM, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is uniformly distributed"
@@ -399,14 +382,14 @@ class UniqueAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.UNIQUE,
             values,
             column_name,
             fields={"n_distinct", "p_distinct", "n_unique", "p_unique"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -418,14 +401,9 @@ class UnsupportedAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.UNSUPPORTED,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.UNSUPPORTED, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] is an unsupported type, check if it needs cleaning or further analysis"
@@ -436,13 +414,14 @@ class ZerosAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
         super().__init__(
             AlertType.ZEROS,
-            values, column_name,
+            values,
+            column_name,
             fields={"n_zeros", "p_zeros"},
-            is_empty=is_empty
+            is_empty=is_empty,
         )
 
     def _get_description(self) -> str:
@@ -454,14 +433,9 @@ class RejectedAlert(Alert):
         self,
         values: Optional[Dict] = {},
         column_name: Optional[str] = None,
-        is_empty: bool = False
+        is_empty: bool = False,
     ):
-        super().__init__(
-            AlertType.REJECTED,
-            values, column_name,
-            set(),
-            is_empty
-        )
+        super().__init__(AlertType.REJECTED, values, column_name, set(), is_empty)
 
     def _get_description(self) -> str:
         return f"[{self.column_name}] was rejected"

--- a/src/ydata_profiling/profile_report.py
+++ b/src/ydata_profiling/profile_report.py
@@ -29,6 +29,7 @@ from ydata_profiling.model.summarizer import (
     BaseSummarizer,
     PandasProfilingSummarizer,
     format_summary,
+    redact_summary,
 )
 from ydata_profiling.model.typeset import ProfilingTypeSet
 from ydata_profiling.report import get_report_structure
@@ -450,6 +451,8 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         ) as pbar:
             description_dict = format_summary(description)
             description_dict = encode_it(description_dict)
+            description_dict = redact_summary(description_dict, self.config)
+
             data = json.dumps(description_dict, indent=4)
             pbar.update()
         return data


### PR DESCRIPTION
Fixed an issue where render_json ignores the redact configuration (i.e. sensitive parameter of ProfileReport). Now the resulting json replaces the values by `READCTED_#`.

e.g.
```
{
  ...
  "variables": {
    "text_var": {
      ...
      "value_counts_without_nan": {
        "REDACTED_0": 2,
        "REDACTED_1": 2,
        ...
      }
     "word_counts": {
       "REDACTED_0": 358,
       "REDACTED_1": 326,
       ...
      }
    },
}
```
fixes https://github.com/ydataai/ydata-profiling/issues/1300