### PR TITLE
fix: infer all `Numeric` vars as `TimeSeries` when tsmode=True

### DIFF
--- a/src/ydata_profiling/model/typeset.py
+++ b/src/ydata_profiling/model/typeset.py
@@ -293,20 +293,7 @@ def typeset_types(config: Settings) -> Set[visions.VisionsBaseType]:
         @series_not_empty
         @series_handle_nulls
         def contains_op(series: pd.Series, state: dict) -> bool:
-            def is_timedependent(series: pd.Series) -> bool:
-                autocorrelation_threshold = config.vars.timeseries.autocorrelation
-                lags = config.vars.timeseries.lags
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore", RuntimeWarning)
-                    for lag in lags:
-                        autcorr = series.autocorr(lag=lag)
-                        if autcorr >= autocorrelation_threshold:
-                            return True
-
-                return False
-
-            is_numeric = pdt.is_numeric_dtype(series) and not pdt.is_bool_dtype(series)
-            return is_numeric and is_timedependent(series)
+            return pdt.is_numeric_dtype(series) and not pdt.is_bool_dtype(series)
 
     types = {Unsupported, Boolean, Numeric, Text, Categorical, DateTime}
     if config.vars.path.active:

--- a/src/ydata_profiling/model/typeset.py
+++ b/src/ydata_profiling/model/typeset.py
@@ -293,7 +293,11 @@ def typeset_types(config: Settings) -> Set[visions.VisionsBaseType]:
         @series_not_empty
         @series_handle_nulls
         def contains_op(series: pd.Series, state: dict) -> bool:
-            return pdt.is_numeric_dtype(series) and not pdt.is_bool_dtype(series)
+            return (
+                pdt.is_numeric_dtype(series)
+                and not pdt.is_bool_dtype(series)
+                and series.nunique() > 1
+            )
 
     types = {Unsupported, Boolean, Numeric, Text, Categorical, DateTime}
     if config.vars.path.active:

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -25,7 +25,7 @@ def html_profile() -> str:
             "constant": np.ones(size),
             "sin": [round(np.sin(x * np.pi / 180), 2) for x in time_steps],
             "cos": [round(np.cos(x * np.pi / 180), 2) for x in time_steps],
-            "uniform": [round(x, 2) for x in np.random.uniform(0, 10, size)],
+            "gaussian": [round(x, 2) for x in np.random.normal(0, 1, size)],
         }
     )
 

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -26,7 +26,6 @@ def html_profile() -> str:
             "sin": [round(np.sin(x * np.pi / 180), 2) for x in time_steps],
             "cos": [round(np.cos(x * np.pi / 180), 2) for x in time_steps],
             "uniform": [round(x, 2) for x in np.random.uniform(0, 10, size)],
-            "gaussian": [round(x, 2) for x in np.random.normal(0, 1, size)],
         }
     )
 
@@ -37,7 +36,7 @@ def html_profile() -> str:
 def test_timeseries_identification(html_profile: str):
     assert "<th>TimeSeries</th>" in html_profile, "TimeSeries not detected"
     assert (
-        "<tr><th>TimeSeries</th><td>8</td></tr>" in html_profile
+        "<tr><th>TimeSeries</th><td>9</td></tr>" in html_profile
     ), "TimeSeries incorrectly identified"
 
 
@@ -46,7 +45,7 @@ def test_timeseries_autocorrelation_tab(html_profile: str):
         "role=tab data-toggle=tab>Autocorrelation<" in html_profile
     ), "TimeSeries not detected"
     assert (
-        html_profile.count("role=tab data-toggle=tab>Autocorrelation<") == 8
+        html_profile.count("role=tab data-toggle=tab>Autocorrelation<") == 9
     ), "TimeSeries autocorrelation tabs incorrectly generated"
 
 


### PR DESCRIPTION
Drop the time dependence check for time series type inference