### PR TITLE
fix: alert not shown for vars with a single alert

### DIFF
--- a/src/ydata_profiling/report/presentation/flavours/html/templates/variable_info.html
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates/variable_info.html
@@ -3,7 +3,7 @@
     <br/>
     <small>{{ var_type }}</small>
 </p>
-{% if alerts | length > 1 %}
+{% if alerts | length > 0 %}
     {% if alerts[0].__class__.__name__ == 'list' %}
         {% set n_labels = style.labels | length %}
         <table width="100%">


### PR DESCRIPTION
The alerts for a variable with a single alert were not displayed in the variables section.