### PR TITLE
fix: {{ file_name }} error in HTML wrapper

### DIFF
--- a/src/ydata_profiling/report/presentation/flavours/html/templates/wrapper/javascript.html
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates/wrapper/javascript.html
@@ -8,9 +8,9 @@
         {% include 'wrapper/assets/script.js' %}
         </script>
     {% else %}
-        <script src="{{ file_name }}_assets/js/jquery-1.12.4.min.js"></script>
-        <script src="{{ file_name }}_assets/js/bootstrap.min.js"></script>
-        <script src="{{ file_name }}_assets/js/script.js"></script>
+        <script src="{{ assets_prefix }}/js/jquery-1.12.4.min.js"></script>
+        <script src="{{ assets_prefix }}/js/bootstrap.min.js"></script>
+        <script src="{{ assets_prefix }}/js/script.js"></script>
     {% endif %}
 {% else %}
     <script src="https://code.jquery.com/jquery-1.12.4.min.js"></script>

--- a/src/ydata_profiling/report/presentation/flavours/html/templates/wrapper/style.html
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates/wrapper/style.html
@@ -19,17 +19,17 @@
     {% else %}
         {% if theme is not none %}
             {% if theme.value == 'flatly' %}
-                <link href="{{ file_name }}_assets/css/flatly.bootstrap.min.css" rel="stylesheet" />
+                <link href="{{ assets_prefix }}/css/flatly.bootstrap.min.css" rel="stylesheet" />
             {% elif theme.value == 'united' %}
-                <link href="{{ file_name }}_assets/css/united.bootstrap.min.css" rel="stylesheet" />
+                <link href="{{ assets_prefix }}/css/united.bootstrap.min.css" rel="stylesheet" />
             {% elif theme.value == 'simplex' %}
-                <link href="{{ file_name }}_assets/css/simplex.bootstrap.min.css" rel="stylesheet" />
+                <link href="{{ assets_prefix }}/css/simplex.bootstrap.min.css" rel="stylesheet" />
             {% elif theme.value == 'cosmo' %}
-                <link href="{{ file_name }}_assets/css/cosmo.bootstrap.min.css" rel="stylesheet" />
+                <link href="{{ assets_prefix }}/css/cosmo.bootstrap.min.css" rel="stylesheet" />
             {% endif %}
         {% else %}
-            <link rel="stylesheet" href="{{ file_name }}_assets/css/bootstrap.min.css" />
-            <link rel="stylesheet" href="{{ file_name }}_assets/css/bootstrap-theme.min.css" />
+            <link rel="stylesheet" href="{{ assets_prefix }}/css/bootstrap.min.css" />
+            <link rel="stylesheet" href="{{ assets_prefix }}/css/bootstrap-theme.min.css" />
         {% endif %}
     {% endif %}
 {% else %}
@@ -52,5 +52,5 @@
 {%- if inline -%}
     <style>{% include 'wrapper/assets/style.css' %}</style>
 {% else %}
-    <link rel="stylesheet" href="{{ file_name }}_assets/css/style.css" />
+    <link rel="stylesheet" href="{{ assets_prefix }}/css/style.css" />
 {% endif %}


### PR DESCRIPTION
When inline is set to FALSE and the report is exported as an html file, {{ file_name }} would render as an empty string and the paths to both the stylesheets and the scripts would be incorrect, causing visualization issues. 

To fix this, the (( file_name }} clause was replaced with {{ assets_prefix }}, which correctly points to the referenced stylesheets and js scripts.