### PR TITLE
fix: handle text as categoricals if sensitive=True

### DIFF
--- a/src/ydata_profiling/report/structure/variables/render_categorical.py
+++ b/src/ydata_profiling/report/structure/variables/render_categorical.py
@@ -339,10 +339,14 @@ def render_categorical(config: Settings, summary: dict) -> dict:
 
     template_variables = render_common(config, summary)
 
+    type_name = summary["type"]
+    if isinstance(type_name, list):
+        type_name = type_name[0]
+
     info = VariableInfo(
         summary["varid"],
         summary["varname"],
-        "Categorical",
+        type_name,
         summary["alerts"],
         summary["description"],
         style=config.html.style,

--- a/src/ydata_profiling/report/structure/variables/render_text.py
+++ b/src/ydata_profiling/report/structure/variables/render_text.py
@@ -12,6 +12,7 @@ from ydata_profiling.report.presentation.core.variable_info import VariableInfo
 from ydata_profiling.report.structure.variables.render_categorical import (
     _get_n,
     freq_table,
+    render_categorical,
     render_categorical_frequency,
     render_categorical_length,
     render_categorical_unicode,
@@ -21,6 +22,10 @@ from ydata_profiling.visualisation.plot import plot_word_cloud
 
 
 def render_text(config: Settings, summary: Dict[str, Any]) -> Dict[str, Any]:
+    if config.vars.text.redact:
+        render = render_categorical(config, summary)
+        return render
+
     varid = summary["varid"]
     words = config.vars.text.words
     characters = config.vars.text.characters


### PR DESCRIPTION
fixes https://github.com/ydataai/ydata-profiling/issues/1377
Handles text variables as categoricals if sensitive is true. Here is an example of a column with random text:

sensitivity = False:
![image](https://github.com/ydataai/ydata-profiling/assets/9274404/8adc05ac-336f-404c-8321-ae9c8a1abe05)
sensitivity = True
![image](https://github.com/ydataai/ydata-profiling/assets/9274404/ca4df021-2136-4ad9-a24f-32828e18362e)
