### PR TITLE
fix: time index and gap analysis bugs

### DIFF
--- a/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
@@ -166,7 +166,7 @@ def compute_gap_stats(series: pd.Series) -> pd.Series:
         base_frequency = 1
 
     diff = gap.diff()
-    anchors = gap[diff > period].index
+    anchors = gap[diff > 2 * period].index
     gaps = []
     for i in anchors:
         gaps.append(gap.loc[gap.index[[i - 1, i]]].values)

--- a/src/ydata_profiling/report/structure/overview.py
+++ b/src/ydata_profiling/report/structure/overview.py
@@ -312,11 +312,13 @@ def get_timeseries_items(config: Settings, summary: BaseDescription) -> Containe
 
     ts_info = Table(table_stats, name="Timeseries statistics", style=config.html.style)
 
+    dpi_bak = config.plot.dpi
+    config.plot.dpi = 300
     timeseries = ImageWidget(
         plot_overview_timeseries(config, summary.variables),
         image_format=config.plot.image_format,
         alt="ts_plot",
-        name="preview",
+        name="original",
         anchor_id="ts_plot_overview",
     )
     timeseries_scaled = ImageWidget(
@@ -326,6 +328,7 @@ def get_timeseries_items(config: Settings, summary: BaseDescription) -> Containe
         name="scaled",
         anchor_id="ts_plot_scaled_overview",
     )
+    config.plot.dpi = dpi_bak
     ts_tab = Container(
         [timeseries, timeseries_scaled],
         anchor_id="ts_plot_overview",

--- a/src/ydata_profiling/report/structure/variables/render_timeseries.py
+++ b/src/ydata_profiling/report/structure/variables/render_timeseries.py
@@ -23,14 +23,8 @@ from ydata_profiling.visualisation.plot import (
 
 
 def _render_gap_tab(config: Settings, summary: dict) -> Container:
-    gap_stats = [
-        {
-            "name": "period",
-            "value": fmt_numeric(
-                summary["gap_stats"]["period"], precision=config.report.precision
-            ),
-        },
-    ]
+    gap_stats = []
+
     if "frequency" in summary["gap_stats"]:
         gap_stats.append(
             {

--- a/src/ydata_profiling/report/structure/variables/render_timeseries.py
+++ b/src/ydata_profiling/report/structure/variables/render_timeseries.py
@@ -23,43 +23,33 @@ from ydata_profiling.visualisation.plot import (
 
 
 def _render_gap_tab(config: Settings, summary: dict) -> Container:
-    gap_stats = []
+    gap_stats = [
+        {
+            "name": "min inverval",
+            "value": fmt_numeric(
+                summary["gap_stats"]["min"], precision=config.report.precision
+            ),
+        },
+        {
+            "name": "max inverval",
+            "value": fmt_numeric(
+                summary["gap_stats"]["max"], precision=config.report.precision
+            ),
+        },
+        {
+            "name": "mean inverval",
+            "value": fmt_numeric(
+                summary["gap_stats"]["mean"], precision=config.report.precision
+            ),
+        },
+        {
+            "name": "interval std",
+            "value": fmt_numeric(
+                summary["gap_stats"]["std"], precision=config.report.precision
+            ),
+        },
+    ]
 
-    if "frequency" in summary["gap_stats"]:
-        gap_stats.append(
-            {
-                "name": "frequency",
-                "value": summary["gap_stats"]["frequency"],
-            }
-        )
-    gap_stats.extend(
-        [
-            {
-                "name": "min inverval",
-                "value": fmt_numeric(
-                    summary["gap_stats"]["min"], precision=config.report.precision
-                ),
-            },
-            {
-                "name": "max inverval",
-                "value": fmt_numeric(
-                    summary["gap_stats"]["max"], precision=config.report.precision
-                ),
-            },
-            {
-                "name": "mean inverval",
-                "value": fmt_numeric(
-                    summary["gap_stats"]["mean"], precision=config.report.precision
-                ),
-            },
-            {
-                "name": "interval std",
-                "value": fmt_numeric(
-                    summary["gap_stats"]["std"], precision=config.report.precision
-                ),
-            },
-        ]
-    )
     gap_table = Table(
         gap_stats,
         name="Intervals statistics",

--- a/src/ydata_profiling/visualisation/plot.py
+++ b/src/ydata_profiling/visualisation/plot.py
@@ -640,7 +640,10 @@ def plot_overview_timeseries(
     else:
         for col, data in variables.items():
             if data["type"] == "TimeSeries":
-                data["series"].plot(ax=ax, label=col)
+                series = data["series"]
+                if scale:
+                    series = (series - series.min()) / (series.max() - series.min())
+                series.plot(ax=ax, label=col, alpha=0.65)
 
     plt.legend(loc="upper right")
     return plot_360_n0sc0pe(config)

--- a/src/ydata_profiling/visualisation/plot.py
+++ b/src/ydata_profiling/visualisation/plot.py
@@ -645,7 +645,8 @@ def plot_overview_timeseries(
                     series = (series - series.min()) / (series.max() - series.min())
                 series.plot(ax=ax, label=col, alpha=0.65)
 
-    plt.legend(loc="upper right")
+    plt.legend(bbox_to_anchor=(1.04, 1), loc="upper left")
+    plt.subplots_adjust(right=0.7)
     return plot_360_n0sc0pe(config)
 
 


### PR DESCRIPTION
fixes:
- scaled tab scaling only for the comparison report
- legend overlapping and hiding part of the plot
- added some to help with the visualization of multiple series (bear in mind that as the number of series increases harder it is to have a comprehensive visualization with all the series)
- removed period and frequency from the gap analysis table since it is constant for all variables and it is available at the time index tab
- added some tolerance for gap identification to avoid false positives
