### PR TITLE
fix: update duplicates_pandas.py

### DIFF
--- a/src/ydata_profiling/model/pandas/duplicates_pandas.py
+++ b/src/ydata_profiling/model/pandas/duplicates_pandas.py
@@ -35,7 +35,7 @@ def pandas_get_duplicates(
             duplicated_rows = df.duplicated(subset=supported_columns, keep=False)
             duplicated_rows = (
                 df[duplicated_rows]
-                .groupby(supported_columns, dropna=False)
+                .groupby(supported_columns, dropna=False, observed=True)
                 .size()
                 .reset_index(name=duplicates_key)
             )


### PR DESCRIPTION
Fixing Bug Report #1384
Dataset with categorical features causes memory error even on tiny dataset.