### PR TITLE
fix: bug when creating a new report

### DIFF
--- a/src/ydata_profiling/profile_report.py
+++ b/src/ydata_profiling/profile_report.py
@@ -67,7 +67,7 @@ class ProfileReport(SerializeReport, ExpectationsReport):
         dark_mode: bool = False,
         orange_mode: bool = False,
         sample: Optional[dict] = None,
-        config_file: Union[Path, str] = None,
+        config_file: Optional[Union[Path, str]] = None,
         lazy: bool = True,
         typeset: Optional[VisionsTypeset] = None,
         summarizer: Optional[BaseSummarizer] = None,


### PR DESCRIPTION
Fix bug when creating a new report.

Caused by the `@typechecked` decorator on the `ProfileReport` class, and missing the `Optional[]` typehint on the `config_file` parameter.

Resolves #1439