### PR TITLE
docs: fix hyperlink - related to package name change

### DIFF
--- a/docs/advanced_settings/tables/config_general.csv
+++ b/docs/advanced_settings/tables/config_general.csv
@@ -1,4 +1,4 @@
 Parameter,Type,Default,Description
 ``title``,string,"Pandas Profiling Report","Title for the report, shown in the header and title bar."
 ``pool_size``,integer,0,"Number of workers in thread pool. When set to zero, it is set to the number of CPUs available."
-``progress_bar``,boolean,``True``,"If ``True``, ``pandas-profiling`` will display a progress bar."
+``progress_bar``,boolean,``True``,"If ``True``, ``ydata-profiling`` will display a progress bar."

--- a/docs/features/big_data.md
+++ b/docs/features/big_data.md
@@ -56,7 +56,7 @@ profile.to_file("output.html")
 ```
 
 This configuration file can be found here:
-[config_minimal.yaml](https://github.com/ydataai/pandas-profiling/blob/master/src/pandas_profiling/config_minimal.yaml).
+[config_minimal.yaml](https://github.com/ydataai/ydata-profiling/blob/master/src/ydata_profiling/config_minimal.yaml).
 More details on settings and configuration are available in
 `../advanced_usage/available_settings`{.interpreted-text role="doc"}.
 

--- a/docs/features/sensitive_data.md
+++ b/docs/features/sensitive_data.md
@@ -10,7 +10,7 @@ report and no individual records are shown:
 report = df.profile_report(sensitive=True)
 ```
 
-Additionally, `pandas-profiling` does not send data to external
+Additionally, `ydata-profiling` does not send data to external
 services, making it suitable for private data.
 
 ## Sample and duplicates


### PR DESCRIPTION
Update pandas-profiling to ydata-profiling in some forgotten places in docs.