### PR TITLE
feat: add density histogram

### DIFF
--- a/src/ydata_profiling/config.py
+++ b/src/ydata_profiling/config.py
@@ -148,6 +148,7 @@ class Histogram(BaseModel):
     # Maximum number of bins (when bins=0)
     max_bins: int = 250
     x_axis_labels: bool = True
+    density: bool = False
 
 
 class CatFrequencyPlot(BaseModel):

--- a/src/ydata_profiling/model/summary_algorithms.py
+++ b/src/ydata_profiling/model/summary_algorithms.py
@@ -39,6 +39,7 @@ def histogram_compute(
     bins = np.histogram_bin_edges(finite_values, bins=bins_arg)
     if len(bins) > hist_config.max_bins:
         bins = np.histogram_bin_edges(finite_values, bins=hist_config.max_bins)
+        weights = weights if weights and len(weights) == hist_config.max_bins else None
 
     stats[name] = np.histogram(
         finite_values, bins=bins, weights=weights, density=config.plot.histogram.density

--- a/src/ydata_profiling/model/summary_algorithms.py
+++ b/src/ydata_profiling/model/summary_algorithms.py
@@ -34,15 +34,15 @@ def histogram_compute(
     weights: Optional[np.ndarray] = None,
 ) -> dict:
     stats = {}
-    bins = config.plot.histogram.bins
-    bins_arg = "auto" if bins == 0 else min(bins, n_unique)
+    hist_config = config.plot.histogram
+    bins_arg = "auto" if hist_config.bins == 0 else min(hist_config.bins, n_unique)
     bins = np.histogram_bin_edges(finite_values, bins=bins_arg)
-    stats[name] = np.histogram(finite_values, bins=bins, weights=weights)
+    if len(bins) > hist_config.max_bins:
+        bins = np.histogram_bin_edges(finite_values, bins=hist_config.max_bins)
 
-    max_bins = config.plot.histogram.max_bins
-    if bins_arg == "auto" and len(stats[name][1]) > max_bins:
-        bins = np.histogram_bin_edges(finite_values, bins=max_bins)
-        stats[name] = np.histogram(finite_values, bins=bins, weights=None)
+    stats[name] = np.histogram(
+        finite_values, bins=bins, weights=weights, density=config.plot.histogram.density
+    )
 
     return stats
 

--- a/tests/unit/test_summary_algos.py
+++ b/tests/unit/test_summary_algos.py
@@ -2,10 +2,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from ydata_profiling.config import Settings
 from ydata_profiling.model.summary_algorithms import (
     describe_counts,
     describe_generic,
     describe_supported,
+    histogram_compute,
 )
 
 
@@ -53,3 +55,26 @@ def test_summary_supported_empty_df(config, empty_data):
     assert summary["p_distinct"] == 0
     assert summary["n_unique"] == 0
     assert not summary["is_unique"]
+
+
+@pytest.fixture
+def numpy_array():
+    return np.random.choice(list(range(10)), size=1000)
+
+
+def test_compute_histogram(numpy_array):
+    config = Settings()
+    n_unique = len(np.unique(numpy_array))
+    hist = histogram_compute(config, numpy_array, n_unique)
+    assert "histogram" in hist
+    assert len(hist["histogram"][0]) == n_unique
+    assert len(hist["histogram"][1]) == n_unique + 1
+    assert sum(hist["histogram"][0]) == len(numpy_array)
+
+    config.plot.histogram.density = True
+    hist = histogram_compute(config, numpy_array, n_unique)
+    assert "histogram" in hist
+    assert len(hist["histogram"][0]) == n_unique
+    assert len(hist["histogram"][1]) == n_unique + 1
+    hist_values = hist["histogram"][0] * np.diff(hist["histogram"][1])
+    assert sum(hist_values) == pytest.approx(1, 0.1)


### PR DESCRIPTION
- Add an option to the histogram config to enable using numpy density parameter
- minor refactoring to avoid computing histogram twice
- add a minimal unity test for histogram_compute

closes https://github.com/ydataai/ydata-profiling/issues/1356