### PR TITLE
fix: table template ignoring text format

### DIFF
--- a/src/ydata_profiling/report/presentation/flavours/html/templates/table.html
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates/table.html
@@ -18,11 +18,11 @@
                 <tr{% if 'alert' in row and row['alert'] %} class="alert"{% endif %}>
                     <th>{{ row['name'] }}</th>
                     {% if row['value'].__class__.__name__ == 'list' %}
-                        {% for value in row['value'] %}
-                            <td>{{ value }}{% if loop.last and 'hint' in row %} {{ row['hint'] }}{% endif %}</td>
+                        {% for value in row['value'] +%}
+                            <td style="white-space:pre white-space:nowrap">{{ value }}{% if loop.last and 'hint' in row %} {{ row['hint'] }}{% endif %}</td>
                         {% endfor %}
                     {% else %}
-                        <td>{{ row['value'] }}{% if 'hint' in row %} {{ row['hint'] }}{% endif %}</td>
+                        <td style="white-space:pre white-space:nowrap">{{ row['value'] }}{% if 'hint' in row %} {{ row['hint'] }}{% endif %}</td>
                     {% endif %}
                 </tr>
             {% endfor %}

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -37,7 +37,7 @@ def html_profile() -> str:
 def test_timeseries_identification(html_profile: str):
     assert "<th>TimeSeries</th>" in html_profile, "TimeSeries not detected"
     assert (
-        "<tr><th>TimeSeries</th><td>8</td></tr>" in html_profile
+        "<tr><th>TimeSeries</th><td style=\"white-space:pre white-space:nowrap\">8</td></tr>" in html_profile
     ), "TimeSeries incorrectly identified"
 
 

--- a/tests/unit/test_time_series.py
+++ b/tests/unit/test_time_series.py
@@ -37,7 +37,8 @@ def html_profile() -> str:
 def test_timeseries_identification(html_profile: str):
     assert "<th>TimeSeries</th>" in html_profile, "TimeSeries not detected"
     assert (
-        "<tr><th>TimeSeries</th><td style=\"white-space:pre white-space:nowrap\">8</td></tr>" in html_profile
+        '<tr><th>TimeSeries</th><td style="white-space:pre white-space:nowrap">8</td></tr>'
+        in html_profile
     ), "TimeSeries incorrectly identified"
 
 


### PR DESCRIPTION
closes https://github.com/ydataai/ydata-profiling/issues/1437
Update the table template to use the string in its original format without overflowing.