### PR TITLE
fix: use deterministic column order for correlations heatmap

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,7 +134,6 @@ plugins:
         lang: en
   - autorefs
   - mkdocstrings:
-      custom_templates: templates
       default_handler: python
       handlers:
         python:

--- a/src/ydata_profiling/model/pandas/correlations_pandas.py
+++ b/src/ydata_profiling/model/pandas/correlations_pandas.py
@@ -104,6 +104,7 @@ def pandas_cramers_compute(
     if len(categoricals) <= 1:
         return None
 
+    categoricals = sorted(categoricals)
     matrix = np.zeros((len(categoricals), len(categoricals)))
     np.fill_diagonal(matrix, 1.0)
     correlation_matrix = pd.DataFrame(

--- a/src/ydata_profiling/model/pandas/correlations_pandas.py
+++ b/src/ydata_profiling/model/pandas/correlations_pandas.py
@@ -183,7 +183,7 @@ def pandas_auto_compute(
     df_discretized = Discretizer(
         DiscretizationType.UNIFORM, n_bins=config.correlations["auto"].n_bins
     ).discretize_dataframe(df)
-    columns_tested = numerical_columns + categorical_columns
+    columns_tested = sorted(numerical_columns) + sorted(categorical_columns)
     correlation_matrix = pd.DataFrame(
         np.ones((len(columns_tested), len(columns_tested))),
         index=columns_tested,

--- a/src/ydata_profiling/model/pandas/correlations_pandas.py
+++ b/src/ydata_profiling/model/pandas/correlations_pandas.py
@@ -184,7 +184,8 @@ def pandas_auto_compute(
     df_discretized = Discretizer(
         DiscretizationType.UNIFORM, n_bins=config.correlations["auto"].n_bins
     ).discretize_dataframe(df)
-    columns_tested = sorted(numerical_columns) + sorted(categorical_columns)
+    columns_tested = sorted(numerical_columns + categorical_columns)
+
     correlation_matrix = pd.DataFrame(
         np.ones((len(columns_tested), len(columns_tested))),
         index=columns_tested,


### PR DESCRIPTION
Sort heatmap columns for correlations `Auto` and `cramer's` to ensure a deterministic order for profiling comparison
