### PR TITLE
fix: 1540 add_expectation_suite doesn't have key overwrite_existing

### DIFF
--- a/src/ydata_profiling/expectations_report.py
+++ b/src/ydata_profiling/expectations_report.py
@@ -80,7 +80,7 @@ class ExpectationsReport:
             data_context = ge.data_context.DataContext()
 
         suite = data_context.add_expectation_suite(
-            suite_name, overwrite_existing=True
+            suite_name
         )
 
         # Instantiate an in-memory pandas dataset

--- a/tests/unit/test_ge_integration.py
+++ b/tests/unit/test_ge_integration.py
@@ -93,7 +93,7 @@ def test_to_expectations_suite_title(context, df):
     )
 
     context.add_expectation_suite.assert_called_once_with(
-        "expectations-dataset", overwrite_existing=True
+        "expectations-dataset"
     )
 
 


### PR DESCRIPTION
Fix https://github.com/ydataai/ydata-profiling/pull/1540 remove keyword argument 'overwrite_existing'.
This aligns with the changes made in https://github.com/great-expectations/great_expectations/pull/7117, great_expectations/data_context/data_context/abstract_data_context.py