### PR TITLE
fix: timeseries gap comparison failing with no gaps for date index

### DIFF
--- a/src/ydata_profiling/expectations_report.py
+++ b/src/ydata_profiling/expectations_report.py
@@ -79,9 +79,7 @@ class ExpectationsReport:
         if not data_context:
             data_context = ge.data_context.DataContext()
 
-        suite = data_context.add_expectation_suite(
-            suite_name, overwrite_existing=True
-        )
+        suite = data_context.add_expectation_suite(suite_name, overwrite_existing=True)
 
         # Instantiate an in-memory pandas dataset
         batch = ge.dataset.PandasDataset(self.df, expectation_suite=suite)

--- a/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
@@ -177,14 +177,16 @@ def compute_gap_stats(series: pd.Series) -> pd.Series:
 
     is_datetime = isinstance(series.index, pd.DatetimeIndex)
     gap_stats, gaps = identify_gaps(gap, is_datetime)
+    has_gaps = len(gap_stats) > 0
 
     stats = {
-        "min": gap_stats.min(),
-        "max": gap_stats.max(),
-        "mean": gap_stats.mean(),
+        "min": gap_stats.min() if has_gaps else 0,
+        "max": gap_stats.max() if has_gaps else 0,
+        "mean": gap_stats.mean() if has_gaps else 0,
         "std": gap_stats.std() if len(gap_stats) > 1 else 0,
         "series": series,
         "gaps": gaps,
+        "n_gaps": len(gaps),
     }
     return stats
 

--- a/src/ydata_profiling/report/structure/overview.py
+++ b/src/ydata_profiling/report/structure/overview.py
@@ -273,7 +273,8 @@ def get_dataset_alerts(config: Settings, alerts: list) -> Alerts:
 
 
 def get_timeseries_items(config: Settings, summary: BaseDescription) -> Container:
-    def format_tsindex_limit(limit: Any) -> str:
+    @list_args
+    def fmt_tsindex_limit(limit: Any) -> str:
         if isinstance(limit, datetime):
             return limit.strftime("%Y-%m-%d %H:%M:%S")
         else:
@@ -291,11 +292,11 @@ def get_timeseries_items(config: Settings, summary: BaseDescription) -> Containe
         },
         {
             "name": "Starting point",
-            "value": format_tsindex_limit(summary.time_index_analysis.start),
+            "value": fmt_tsindex_limit(summary.time_index_analysis.start),
         },
         {
             "name": "Ending point",
-            "value": format_tsindex_limit(summary.time_index_analysis.end),
+            "value": fmt_tsindex_limit(summary.time_index_analysis.end),
         },
         {
             "name": "Period",

--- a/src/ydata_profiling/report/structure/variables/render_timeseries.py
+++ b/src/ydata_profiling/report/structure/variables/render_timeseries.py
@@ -28,7 +28,7 @@ def _render_gap_tab(config: Settings, summary: dict) -> Container:
         {
             "name": "number of gaps",
             "value": fmt_numeric(
-                len(summary["gap_stats"]["gaps"]), precision=config.report.precision
+                summary["gap_stats"]["n_gaps"], precision=config.report.precision
             ),
         },
         {


### PR DESCRIPTION
When calculating gap statistics for date indexes, when there were no gaps the gap_stats.min() returned a NaT which lead to failures while trying to render it.
Also fixed a small error on time series statistics overview tab