### PR TITLE
fix: zero division for categorical colums with 100% missing data

### DIFF
--- a/src/ydata_profiling/model/pandas/describe_boolean_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_boolean_pandas.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 
 from ydata_profiling.config import Settings
 from ydata_profiling.model.pandas.imbalance_pandas import column_imbalance_score
@@ -32,10 +32,12 @@ def pandas_describe_boolean_1d(
         summary.update({"top": value_counts.index[0], "freq": value_counts.iloc[0]})
         summary["imbalance"] = column_imbalance_score(value_counts, len(value_counts))
     else:
-        summary.update({
-            "top": np.nan,
-            "freq": 0,
-            "imbalance": 0,
-        })
+        summary.update(
+            {
+                "top": np.nan,
+                "freq": 0,
+                "imbalance": 0,
+            }
+        )
 
     return config, series, summary

--- a/src/ydata_profiling/model/pandas/describe_boolean_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_boolean_pandas.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 import pandas as pd
+import numpy as np
 
 from ydata_profiling.config import Settings
 from ydata_profiling.model.pandas.imbalance_pandas import column_imbalance_score
@@ -26,9 +27,15 @@ def pandas_describe_boolean_1d(
         A dict containing calculated series description values.
     """
 
-    value_counts = summary["value_counts_without_nan"]
-    summary.update({"top": value_counts.index[0], "freq": value_counts.iloc[0]})
-
-    summary["imbalance"] = column_imbalance_score(value_counts, len(value_counts))
+    value_counts: pd.Series = summary["value_counts_without_nan"]
+    if not value_counts.empty:
+        summary.update({"top": value_counts.index[0], "freq": value_counts.iloc[0]})
+        summary["imbalance"] = column_imbalance_score(value_counts, len(value_counts))
+    else:
+        summary.update({
+            "top": np.nan,
+            "freq": 0,
+            "imbalance": 0,
+        })
 
     return config, series, summary

--- a/src/ydata_profiling/model/pandas/describe_categorical_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_categorical_pandas.py
@@ -195,10 +195,12 @@ def length_summary_vc(vc: pd.Series) -> dict:
 
     summary = {
         "max_length": np.max(length_counts.index),
-        "mean_length": np.average(length_counts.index, weights=length_counts.values),
+        "mean_length": np.average(
+            length_counts.index, weights=length_counts.values
+            )  if not length_counts.empty else np.nan,
         "median_length": weighted_median(
             length_counts.index.values, weights=length_counts.values
-        ),
+        ) if not length_counts.empty else np.nan,
         "min_length": np.min(length_counts.index),
         "length_histogram": length_counts,
     }

--- a/src/ydata_profiling/model/pandas/describe_categorical_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_categorical_pandas.py
@@ -195,12 +195,14 @@ def length_summary_vc(vc: pd.Series) -> dict:
 
     summary = {
         "max_length": np.max(length_counts.index),
-        "mean_length": np.average(
-            length_counts.index, weights=length_counts.values
-            )  if not length_counts.empty else np.nan,
+        "mean_length": np.average(length_counts.index, weights=length_counts.values)
+        if not length_counts.empty
+        else np.nan,
         "median_length": weighted_median(
             length_counts.index.values, weights=length_counts.values
-        ) if not length_counts.empty else np.nan,
+        )
+        if not length_counts.empty
+        else np.nan,
         "min_length": np.min(length_counts.index),
         "length_histogram": length_counts,
     }

--- a/src/ydata_profiling/model/pandas/describe_date_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_date_pandas.py
@@ -29,16 +29,26 @@ def pandas_describe_date_1d(
     Returns:
         A dict containing calculated series description values.
     """
-    summary.update(
-        {
-            "min": pd.Timestamp.to_pydatetime(series.min()),
-            "max": pd.Timestamp.to_pydatetime(series.max()),
-        }
-    )
+    if summary["value_counts_without_nan"].empty:
+        values = series.values
+        summary.update(
+            {
+                "min": pd.NaT,
+                "max": pd.NaT,
+                "range": 0,
+            }
+        )
+    else:
+        summary.update(
+            {
+                "min": pd.Timestamp.to_pydatetime(series.min()),
+                "max": pd.Timestamp.to_pydatetime(series.max()),
+            }
+        )
 
-    summary["range"] = summary["max"] - summary["min"]
+        summary["range"] = summary["max"] - summary["min"]
 
-    values = series.values.astype(np.int64) // 10**9
+        values = series.values.astype(np.int64) // 10**9
 
     if config.vars.num.chi_squared_threshold > 0.0:
         summary["chi_squared"] = chi_square(values)

--- a/src/ydata_profiling/model/summary_algorithms.py
+++ b/src/ydata_profiling/model/summary_algorithms.py
@@ -34,6 +34,8 @@ def histogram_compute(
     weights: Optional[np.ndarray] = None,
 ) -> dict:
     stats = {}
+    if len(finite_values) == 0:
+        return {name: []}
     hist_config = config.plot.histogram
     bins_arg = "auto" if hist_config.bins == 0 else min(hist_config.bins, n_unique)
     bins = np.histogram_bin_edges(finite_values, bins=bins_arg)
@@ -54,6 +56,8 @@ def chi_square(
     if histogram is None:
         bins = np.histogram_bin_edges(values, bins="auto")
         histogram, _ = np.histogram(values, bins=bins)
+    if len(histogram) == 0 or np.sum(histogram) == 0:
+        return {"statistic": np.nan, "pvalue": np.nan}
     return dict(chisquare(histogram)._asdict())
 
 

--- a/src/ydata_profiling/model/summary_algorithms.py
+++ b/src/ydata_profiling/model/summary_algorithms.py
@@ -57,7 +57,7 @@ def chi_square(
         bins = np.histogram_bin_edges(values, bins="auto")
         histogram, _ = np.histogram(values, bins=bins)
     if len(histogram) == 0 or np.sum(histogram) == 0:
-        return {"statistic": np.nan, "pvalue": np.nan}
+        return {"statistic": 0, "pvalue": 0}
     return dict(chisquare(histogram)._asdict())
 
 

--- a/src/ydata_profiling/report/structure/variables/render_date.py
+++ b/src/ydata_profiling/report/structure/variables/render_date.py
@@ -103,7 +103,7 @@ def render_date(config: Settings, summary: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     # Bottom
-    n_bins = len(summary['histogram'][1]) - 1 if summary['histogram'] else 0
+    n_bins = len(summary["histogram"][1]) - 1 if summary["histogram"] else 0
     bottom = Container(
         [
             Image(

--- a/src/ydata_profiling/report/structure/variables/render_date.py
+++ b/src/ydata_profiling/report/structure/variables/render_date.py
@@ -103,13 +103,14 @@ def render_date(config: Settings, summary: Dict[str, Any]) -> Dict[str, Any]:
         )
 
     # Bottom
+    n_bins = len(summary['histogram'][1]) - 1 if summary['histogram'] else 0
     bottom = Container(
         [
             Image(
                 hist_data,
                 image_format=image_format,
                 alt="Histogram",
-                caption=f"<strong>Histogram with fixed size bins</strong> (bins={len(summary['histogram'][1]) - 1})",
+                caption=f"<strong>Histogram with fixed size bins</strong> (bins={n_bins})",
                 name="Histogram",
                 anchor_id=f"{varid}histogram",
             )


### PR DESCRIPTION
Avoid error thrown when empty column is set as categorical with the _type_schema_