### PR TITLE
chore(deps): remove seaborn upper limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ phik>=0.11.1,<0.13
 requests>=2.24.0, <3
 # Progress bar
 tqdm>=4.48.2, <5
-seaborn>=0.10.1, <0.13
+seaborn>=0.10.1
 multimethod>=1.4, <2
 # metrics
 statsmodels>=0.13.2, <1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ phik>=0.11.1,<0.13
 requests>=2.24.0, <3
 # Progress bar
 tqdm>=4.48.2, <5
-seaborn>=0.10.1, <=0.14
+seaborn>=0.10.1, <0.14
 multimethod>=1.4, <2
 # metrics
 statsmodels>=0.13.2, <1

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ phik>=0.11.1,<0.13
 requests>=2.24.0, <3
 # Progress bar
 tqdm>=4.48.2, <5
-seaborn>=0.10.1
+seaborn>=0.10.1, <=0.14
 multimethod>=1.4, <2
 # metrics
 statsmodels>=0.13.2, <1


### PR DESCRIPTION
Seaborn 0.13 fixes an issue with annotating heatmaps and I'd like to be able to use ydata-profiling in a repository that needs this fix.

I checked git blame and didn't see a reason for the upper-bound pin. I tested on 0.13.2 with Python 3.10 and all unit tests passed.