### PR TITLE
chore: update python3statement url

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ pip install -e .
 
 The profiling report is written in HTML and CSS, which means a modern browser is required. 
 
-You need [Python 3](https://python3statement.org/) to run the package. Other dependencies can be found in the requirements files:
+You need [Python 3](https://python3statement.github.io/) to run the package. Other dependencies can be found in the requirements files:
 
 | Filename | Requirements|
 |----------|-------------|


### PR DESCRIPTION
See python3statement/python3statement.github.io#292.

To avoid having to pay for the domain indefinitely the maintainers are now redirecting to GitHub Pages.