### PR TITLE
fix: Use correct value in ConstantAlert template

### DIFF
--- a/src/ydata_profiling/report/presentation/flavours/html/templates/alerts/alert_constant.html
+++ b/src/ydata_profiling/report/presentation/flavours/html/templates/alerts/alert_constant.html
@@ -1,1 +1,1 @@
-<a href="#pp_var_{{ alert.anchor_id }}"><code>{{ alert.column_name }}</code></a> has constant value "{{ alert.values['mode'] }}"
+<a href="#pp_var_{{ alert.anchor_id }}"><code>{{ alert.column_name }}</code></a> has constant value "{{ alert.values['value_counts_without_nan'].index[0] }}"


### PR DESCRIPTION
As part of #1132, the calculation of `summary["mode"]` was removed ([here](https://github.com/ydataai/ydata-profiling/pull/1132/commits/ec976c8a786fc2a563f2fa080d80c1b70494655a)). However, the template still refers to this value and results in a less helpful error message as below:

![image](https://github.com/ydataai/ydata-profiling/assets/6286038/b6adc093-b4fc-4cb3-8c4b-2e0c9d5f46b7)

This PR changes the template so that the correct value is used:

![image](https://github.com/ydataai/ydata-profiling/assets/6286038/80006961-4601-4338-a654-107c756bef9a)
