### PR TITLE
feat: Add font_path arg for wordcloud

### DIFF
--- a/src/ydata_profiling/config.py
+++ b/src/ydata_profiling/config.py
@@ -173,6 +173,7 @@ class Plot(BaseModel):
     histogram: Histogram = Histogram()
     scatter_threshold: int = 1000
     cat_freq: CatFrequencyPlot = CatFrequencyPlot()
+    font_path: Optional[Union[Path, str]] = None
 
 
 class Theme(Enum):

--- a/src/ydata_profiling/config_default.yaml
+++ b/src/ydata_profiling/config_default.yaml
@@ -159,6 +159,8 @@ plot:
         # Maximum number of bins (when bins=0)
         max_bins: 250
 
+    font_path: null
+
 # The number of observations to show
 n_obs_unique: 5
 n_extreme_obs: 5

--- a/src/ydata_profiling/config_minimal.yaml
+++ b/src/ydata_profiling/config_minimal.yaml
@@ -159,6 +159,8 @@ plot:
         # Maximum number of bins (when bins=0)
         max_bins: 250
 
+    font_path: null
+
 # The number of observations to show
 n_obs_unique: 5
 n_extreme_obs: 5

--- a/src/ydata_profiling/visualisation/plot.py
+++ b/src/ydata_profiling/visualisation/plot.py
@@ -27,6 +27,7 @@ def format_fn(tick_val: int, tick_pos: Any) -> str:
 
 
 def _plot_word_cloud(
+    config: Settings,
     series: Union[pd.Series, List[pd.Series]],
     figsize: tuple = (6, 4),
 ) -> plt.Figure:
@@ -36,7 +37,12 @@ def _plot_word_cloud(
     for i, series_data in enumerate(series):
         word_dict = series_data.to_dict()
         wordcloud = WordCloud(
-            background_color="white", random_state=123, width=300, height=200, scale=2
+            font_path=config.plot.font_path,
+            background_color="white",
+            random_state=123,
+            width=300,
+            height=200,
+            scale=2,
         ).generate_from_frequencies(word_dict)
 
         ax = plot.add_subplot(1, len(series), i + 1)
@@ -124,7 +130,7 @@ def _plot_histogram(
 
 @manage_matplotlib_context()
 def plot_word_cloud(config: Settings, word_counts: pd.Series) -> str:
-    _plot_word_cloud(series=word_counts)
+    _plot_word_cloud(config=config, series=word_counts)
     return plot_360_n0sc0pe(config)
 
 


### PR DESCRIPTION
This PR is a proposed solution to issue #1466.
The default font in Wordcloud is `DruidSansMono.ttf`, and if the languages ​​of the values ​​are different, the image may be broken.

* Example data (language: korean)
![image](https://github.com/ydataai/ydata-profiling/assets/17918068/f4dbcc1e-c802-4757-89ee-811587fb904a)
![image](https://github.com/ydataai/ydata-profiling/assets/17918068/c9a25886-ef11-4cf4-81a8-dc123f9e78eb)

This is a known solution when using wordcloud, but the problem could not be solved because the 'font_path' argument was not specified in ydata_profiling.

I added a setting variable to 'Settings.plot' to pass the value to the font_path argument of word cloud.
Actually, I'm not sure if it's appropriate to put it here.
I just thought that it was a variable for wordcloud plot rendering, and the criterion for judgment was that I thought it could be used in other matplotlib plots as well.

If you do the following, you can check that the wordcloud is displayed normally.
```
profile_report = ProfileReport(df, title="test", minimal=True, plot={"font_path": "/Users/user/Downloads/Nanum_Gothic/NanumGothic-Regular.ttf"})
```

![image](https://github.com/ydataai/ydata-profiling/assets/17918068/44f2308a-5857-473f-84bc-bfc8773a1e94)
