### PR TITLE
fix: timeseries_heatmap

### DIFF
--- a/src/ydata_profiling/visualisation/plot.py
+++ b/src/ydata_profiling/visualisation/plot.py
@@ -833,12 +833,12 @@ def _prepare_heatmap_data(
     )
 
     df = df.groupby([entity_column, "__bins"])[sortbykey].count()
-    df = df.reset_index().pivot_table(entity_column, "__bins", sortbykey).T
+    df = df.reset_index().pivot_table(values=sortbykey, index="__bins", columns=entity_column).T
 
     if selected_entities:
-        df = df[selected_entities].T
+        df = df[selected_entities]
     else:
-        df = df.T[:max_entities]
+        df = df[:max_entities]
 
     return df
 

--- a/tests/unit/test_plot.py
+++ b/tests/unit/test_plot.py
@@ -92,3 +92,9 @@ def test_timeseries_heatmap(dataframe: pd.DataFrame):
     df = _prepare_heatmap_data(dataframe, "entity")
     plot = _create_timeseries_heatmap(df)
     assert isinstance(plot, Axes)
+
+    dataframe["entity"] = dataframe["entity"].astype(str)
+    df = _prepare_heatmap_data(dataframe, "entity")
+    plot = _create_timeseries_heatmap(df)
+    assert isinstance(plot, Axes)
+


### PR DESCRIPTION
`timeseries_heatmap` from `ydata_profiling.visualisation.plot` drops an error, when 'entity_column' is of type str.
The reason for this is that the arguments to `pivot_table` are passed in the wrong order - see [documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pivot_table.html). 

Existing unit test does not cover a case where entities are strings, thus the bug was missed.