### PR TITLE
fix: remove compare report type enforcement

### DIFF
--- a/src/ydata_profiling/compare_reports.py
+++ b/src/ydata_profiling/compare_reports.py
@@ -138,10 +138,6 @@ def _compare_profile_report_preprocess(
                     config.html.style.primary_colors
                 )
 
-    # enforce same types
-    for report in reports[1:]:
-        report._typeset = reports[0].typeset
-
     # Obtain description sets
     descriptions = [report.get_description() for report in reports]
     for label, description in zip(labels, descriptions):


### PR DESCRIPTION
Comparison report type enforcement was only working when both profiles were not pre-computed. When the reference profile had  columns that were not present in the compared profile, it was leading to errors in the type inference step.