### PR TITLE
fix: Correction for numpy.NaN deprecating to numpy.nan

### DIFF
--- a/src/ydata_profiling/model/pandas/describe_numeric_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_numeric_pandas.py
@@ -138,7 +138,7 @@ def pandas_describe_numeric_1d(
         }
     )
     stats["iqr"] = stats["75%"] - stats["25%"]
-    stats["cv"] = stats["std"] / stats["mean"] if stats["mean"] else np.NaN
+    stats["cv"] = stats["std"] / stats["mean"] if stats["mean"] else np.nan
     stats["p_zeros"] = stats["n_zeros"] / summary["n"]
     stats["p_infinite"] = summary["n_infinite"] / summary["n"]
 


### PR DESCRIPTION
Correction for the error:

`AttributeError: `np.NaN` was removed in the NumPy 2.0 release. Use `np.nan` instead.`