### PR TITLE
feat: add adfuller stationary test parameters to config

### DIFF
--- a/src/ydata_profiling/config.py
+++ b/src/ydata_profiling/config.py
@@ -1,7 +1,7 @@
 """Configuration for the package."""
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import yaml
 from pydantic.v1 import BaseModel, BaseSettings, Field, PrivateAttr
@@ -112,6 +112,8 @@ class TimeseriesVars(BaseModel):
     lags: List[int] = [1, 7, 12, 24, 30]
     significance: float = 0.05
     pacf_acf_lag: int = 100
+    autolag: Optional[Literal["AIC", "BIC", "t-stat"]] = "AIC"
+    maxlag: Optional[int] = None
 
 
 class Univariate(BaseModel):

--- a/src/ydata_profiling/config.py
+++ b/src/ydata_profiling/config.py
@@ -6,12 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import yaml
 from pydantic.v1 import BaseModel, BaseSettings, Field, PrivateAttr
 
-try:
-    # typing only available in python 3.8+
-    from typing import Literal
-    AutoLagType = Literal["AIC", "BIC", "t-stat"]
-except:
-    AutoLagType = str
 
 def _merge_dictionaries(dict1: dict, dict2: dict) -> dict:
     """
@@ -118,7 +112,7 @@ class TimeseriesVars(BaseModel):
     lags: List[int] = [1, 7, 12, 24, 30]
     significance: float = 0.05
     pacf_acf_lag: int = 100
-    autolag: Optional[AutoLagType] = "AIC"
+    autolag: Optional[str] = "AIC"
     maxlag: Optional[int] = None
 
 

--- a/src/ydata_profiling/config.py
+++ b/src/ydata_profiling/config.py
@@ -1,11 +1,17 @@
 """Configuration for the package."""
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import yaml
 from pydantic.v1 import BaseModel, BaseSettings, Field, PrivateAttr
 
+try:
+    # typing only available in python 3.8+
+    from typing import Literal
+    AutoLagType = Literal["AIC", "BIC", "t-stat"]
+except:
+    AutoLagType = str
 
 def _merge_dictionaries(dict1: dict, dict2: dict) -> dict:
     """
@@ -112,7 +118,7 @@ class TimeseriesVars(BaseModel):
     lags: List[int] = [1, 7, 12, 24, 30]
     significance: float = 0.05
     pacf_acf_lag: int = 100
-    autolag: Optional[Literal["AIC", "BIC", "t-stat"]] = "AIC"
+    autolag: Optional[AutoLagType] = "AIC"
     maxlag: Optional[int] = None
 
 

--- a/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
@@ -20,7 +20,7 @@ def stationarity_test(config: Settings, series: pd.Series) -> Tuple[bool, float]
     adfuller_test = adfuller(
         series.dropna(),
         autolag=config.vars.timeseries.autolag,
-        maxlag=config.vars.timeseries.maxlag
+        maxlag=config.vars.timeseries.maxlag,
     )
     p_value = adfuller_test[1]
 

--- a/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_timeseries_pandas.py
@@ -16,12 +16,15 @@ from ydata_profiling.model.summary_algorithms import (
 
 
 def stationarity_test(config: Settings, series: pd.Series) -> Tuple[bool, float]:
-    significance_threshold = config.vars.timeseries.significance
-
     # make sure the data has no missing values
-    adfuller_test = adfuller(series.dropna())
+    adfuller_test = adfuller(
+        series.dropna(),
+        autolag=config.vars.timeseries.autolag,
+        maxlag=config.vars.timeseries.maxlag
+    )
     p_value = adfuller_test[1]
 
+    significance_threshold = config.vars.timeseries.significance
     return p_value < significance_threshold, p_value
 
 


### PR DESCRIPTION
Add `autolag` and `maxlag` parameters to config. These parameters can be added to the profiling configuration file under the timeseries vars:
```
vars:
    timeseries:
        autolag: AIC
        maxlag: 30
        significance: 0.05
```
closes https://github.com/ydataai/ydata-profiling/issues/1639