### PR TITLE
fix: updated scipy version to allow 1.14.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scipy>=1.4.1, <1.14
+scipy>=1.4.1, <1.15
 pandas>1.1, <3, !=1.4.0
 matplotlib>=3.5, <3.10
 pydantic>=2


### PR DESCRIPTION
Updated `requirements.txt` to support Scipy versions 1.14.x

closes : #1648 