### PR TITLE
fix: convert multiIndex columns to string representation

### DIFF
--- a/src/ydata_profiling/model/pandas/dataframe_pandas.py
+++ b/src/ydata_profiling/model/pandas/dataframe_pandas.py
@@ -32,5 +32,5 @@ def pandas_preprocess(config: Settings, df: pd.DataFrame) -> pd.DataFrame:
     df = rename_index(df)
 
     # Ensure that columns are strings
-    df.columns = df.columns.astype("str")
+    df.columns = df.columns.map(str)
     return df

--- a/tests/unit/test_multiindex_columns.py
+++ b/tests/unit/test_multiindex_columns.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+
+from ydata_profiling import ProfileReport
+
+
+@pytest.fixture()
+def df():
+    df = pd.DataFrame(
+        {
+            ("foo", "one"): [1, 2, 3],
+            ("bar", "two"): [4, 5, 6],
+        }
+    )
+    return df
+
+
+def test_multiindex_columns(df: pd.DataFrame):
+    profile_report = ProfileReport(df, title="Test Report", progress_bar=False)
+    assert len(profile_report.to_html()) > 0


### PR DESCRIPTION
Previously, report generation failed for DataFrames with a MultiIndex on the column axis due to a "TypeError: Setting a MultiIndex dtype to anything other than object is not supported."
This update converts all indexes to their string representation: simple indexes remain unchanged, while MultiIndexes are represented in a tuple-style format.