### PR TITLE
fix: typeset invalid dates errors

### DIFF
--- a/src/ydata_profiling/model/pandas/describe_date_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_date_pandas.py
@@ -67,9 +67,11 @@ def pandas_describe_date_1d(
         summary["chi_squared"] = chi_square(values)
 
     summary.update(histogram_compute(config, values, series.nunique()))
-    summary.update({
-        "invalid_dates": invalid_values.nunique(),
-        "n_invalid_dates": len(invalid_values),
-        "p_invalid_dates": len(invalid_values) / summary["n"],
-    })
+    summary.update(
+        {
+            "invalid_dates": invalid_values.nunique(),
+            "n_invalid_dates": len(invalid_values),
+            "p_invalid_dates": len(invalid_values) / summary["n"],
+        }
+    )
     return config, values, summary

--- a/src/ydata_profiling/model/pandas/describe_date_pandas.py
+++ b/src/ydata_profiling/model/pandas/describe_date_pandas.py
@@ -14,7 +14,7 @@ from ydata_profiling.model.summary_algorithms import (
 from ydata_profiling.model.typeset_relations import is_pandas_1
 
 
-def string_to_datetime(series: pd.Series) -> pd.Series:
+def to_datetime(series: pd.Series) -> pd.Series:
     if is_pandas_1():
         return pd.to_datetime(series, errors="coerce")
     return pd.to_datetime(series, format="mixed", errors="coerce")
@@ -37,7 +37,7 @@ def pandas_describe_date_1d(
         A dict containing calculated series description values.
     """
     og_series = series.dropna()
-    series = string_to_datetime(og_series)
+    series = to_datetime(og_series)
     invalid_values = og_series[series.isna()]
 
     series = series.dropna()

--- a/src/ydata_profiling/model/pandas/summary_pandas.py
+++ b/src/ydata_profiling/model/pandas/summary_pandas.py
@@ -44,9 +44,6 @@ def pandas_describe_1d(
         and series.name in typeset.type_schema
     ):
         vtype = typeset.type_schema[series.name]
-        infered_vtype = typeset.infer_type(series)
-        if vtype == infered_vtype:
-            series = typeset.cast_to_inferred(series)
 
     elif config.infer_dtypes:
         # Infer variable types

--- a/src/ydata_profiling/model/pandas/summary_pandas.py
+++ b/src/ydata_profiling/model/pandas/summary_pandas.py
@@ -44,6 +44,10 @@ def pandas_describe_1d(
         and series.name in typeset.type_schema
     ):
         vtype = typeset.type_schema[series.name]
+        infered_vtype = typeset.infer_type(series)
+        if vtype == infered_vtype:
+            series = typeset.cast_to_inferred(series)
+
     elif config.infer_dtypes:
         # Infer variable types
         vtype = typeset.infer_type(series)

--- a/src/ydata_profiling/model/typeset_relations.py
+++ b/src/ydata_profiling/model/typeset_relations.py
@@ -114,8 +114,8 @@ def string_is_numeric(series: pd.Series, state: dict, k: Settings) -> bool:
 
 def string_to_datetime(series: pd.Series, state: dict) -> pd.Series:
     if is_pandas_1():
-        return pd.to_datetime(series, errors="coerce")
-    return pd.to_datetime(series, format="mixed", errors="coerce")
+        return pd.to_datetime(series)
+    return pd.to_datetime(series, format="mixed")
 
 
 def string_to_numeric(series: pd.Series, state: dict) -> pd.Series:

--- a/src/ydata_profiling/model/typeset_relations.py
+++ b/src/ydata_profiling/model/typeset_relations.py
@@ -114,8 +114,8 @@ def string_is_numeric(series: pd.Series, state: dict, k: Settings) -> bool:
 
 def string_to_datetime(series: pd.Series, state: dict) -> pd.Series:
     if is_pandas_1():
-        return pd.to_datetime(series)
-    return pd.to_datetime(series, format="mixed")
+        return pd.to_datetime(series, errors="coerce")
+    return pd.to_datetime(series, format="mixed", errors="coerce")
 
 
 def string_to_numeric(series: pd.Series, state: dict) -> pd.Series:

--- a/src/ydata_profiling/report/structure/variables/render_date.py
+++ b/src/ydata_profiling/report/structure/variables/render_date.py
@@ -62,6 +62,16 @@ def render_date(config: Settings, summary: Dict[str, Any]) -> Dict[str, Any]:
         [
             {"name": "Minimum", "value": fmt(summary["min"]), "alert": False},
             {"name": "Maximum", "value": fmt(summary["max"]), "alert": False},
+            {
+                "name": "Invalid dates",
+                "value": fmt(summary["n_invalid_dates"]),
+                "alert": False,
+            },
+            {
+                "name": "Invalid dates (%)",
+                "value": fmt_percent(summary["p_invalid_dates"]),
+                "alert": False,
+            },
         ],
         style=config.html.style,
     )

--- a/tests/unit/test_describe.py
+++ b/tests/unit/test_describe.py
@@ -582,3 +582,23 @@ def test_describe_list(summarizer, typeset):
 
     with pytest.raises(NotImplementedError):
         describe(config, "", [1, 2, 3], summarizer, typeset)
+
+
+def test_decribe_series_type_schema(config, summarizer):
+    "Test describe with invalid date types."
+    typeset = ProfilingTypeSet(config, type_schema={"date": "datetime"})
+    data = {
+        'value': [1, 2, 3, 4],
+        'date': ['0001-01-01', '9999-12-31', '2022-10-03', '2022-10-04']
+    }
+    df = pd.DataFrame(data)
+    result = describe(config, df, summarizer, typeset)
+    
+    assert result.variables["date"]["type"] == "DateTime"
+    assert result.variables["date"]["n_missing"] == 2
+
+    typeset = ProfilingTypeSet(config)
+    result = describe(config, df, summarizer, typeset)
+    
+    assert result.variables["date"]["type"] == "DateTime"
+    assert result.variables["date"]["n_missing"] == 2

--- a/tests/unit/test_describe.py
+++ b/tests/unit/test_describe.py
@@ -595,10 +595,6 @@ def test_decribe_series_type_schema(config, summarizer):
     result = describe(config, df, summarizer, typeset)
 
     assert result.variables["date"]["type"] == "DateTime"
-    assert result.variables["date"]["n_missing"] == 2
-
-    typeset = ProfilingTypeSet(config)
-    result = describe(config, df, summarizer, typeset)
-
-    assert result.variables["date"]["type"] == "DateTime"
-    assert result.variables["date"]["n_missing"] == 2
+    assert result.variables["date"]["n_missing"] == 0
+    assert result.variables["date"]["n_invalid_dates"] == 2
+    assert result.variables["date"]["p_invalid_dates"] == 0.5

--- a/tests/unit/test_describe.py
+++ b/tests/unit/test_describe.py
@@ -588,17 +588,17 @@ def test_decribe_series_type_schema(config, summarizer):
     "Test describe with invalid date types."
     typeset = ProfilingTypeSet(config, type_schema={"date": "datetime"})
     data = {
-        'value': [1, 2, 3, 4],
-        'date': ['0001-01-01', '9999-12-31', '2022-10-03', '2022-10-04']
+        "value": [1, 2, 3, 4],
+        "date": ["0001-01-01", "9999-12-31", "2022-10-03", "2022-10-04"],
     }
     df = pd.DataFrame(data)
     result = describe(config, df, summarizer, typeset)
-    
+
     assert result.variables["date"]["type"] == "DateTime"
     assert result.variables["date"]["n_missing"] == 2
 
     typeset = ProfilingTypeSet(config)
     result = describe(config, df, summarizer, typeset)
-    
+
     assert result.variables["date"]["type"] == "DateTime"
     assert result.variables["date"]["n_missing"] == 2


### PR DESCRIPTION
Fixes conversion errors for DateTime types, when receiving unsupported dates (e.g. '0001-01-01').
With this fix the the invalid dates will be ignored when calculating the metrics that depend on the datetime types, while others (e.g. distinct values) will consider the date without any transformation.

It will also display the amount of invalid values identified
![image](https://github.com/user-attachments/assets/ab693d25-7c74-4f61-90d8-c34dcc1295bf)
