### PR TITLE
fix: type schema not checking for empty columns

### DIFF
--- a/src/ydata_profiling/model/alerts.py
+++ b/src/ydata_profiling/model/alerts.py
@@ -634,7 +634,7 @@ def supported_alerts(summary: dict) -> List[Alert]:
     return alerts
 
 
-def unsupported_alerts(summary: Dict[str, Any]) -> List[Alert]:
+def unsupported_alerts() -> List[Alert]:
     alerts: List[Alert] = [
         UnsupportedAlert(),
         RejectedAlert(),
@@ -657,7 +657,7 @@ def check_variable_alerts(config: Settings, col: str, description: dict) -> List
     alerts += generic_alerts(description)
 
     if description["type"] == "Unsupported":
-        alerts += unsupported_alerts(description)
+        alerts += unsupported_alerts()
     else:
         alerts += supported_alerts(description)
 

--- a/src/ydata_profiling/model/pandas/summary_pandas.py
+++ b/src/ydata_profiling/model/pandas/summary_pandas.py
@@ -42,6 +42,7 @@ def pandas_describe_1d(
         isinstance(typeset, ProfilingTypeSet)
         and typeset.type_schema
         and series.name in typeset.type_schema
+        and not series.isna().all()
     ):
         vtype = typeset.type_schema[series.name]
 

--- a/src/ydata_profiling/model/pandas/summary_pandas.py
+++ b/src/ydata_profiling/model/pandas/summary_pandas.py
@@ -49,10 +49,7 @@ def pandas_describe_1d(
     has_cast_type = _is_cast_type_defined(typeset, series.name)
     cast_type = str(typeset.type_schema[series.name]) if has_cast_type else None
 
-    if (
-        has_cast_type
-        and not series.isna().all()
-    ):
+    if has_cast_type and not series.isna().all():
         vtype = typeset.type_schema[series.name]
 
     elif config.infer_dtypes:
@@ -71,6 +68,7 @@ def pandas_describe_1d(
     summary["cast_type"] = cast_type
 
     return summary
+
 
 @get_series_descriptions.register
 def pandas_get_series_descriptions(

--- a/src/ydata_profiling/report/structure/variables/render_generic.py
+++ b/src/ydata_profiling/report/structure/variables/render_generic.py
@@ -12,7 +12,7 @@ def render_generic(config: Settings, summary: dict) -> dict:
     info = VariableInfo(
         anchor_id=summary["varid"],
         alerts=summary["alerts"],
-        var_type="Unsupported",
+        var_type=summary["cast_type"] or "Unsupported",
         var_name=summary["varname"],
         description=summary["description"],
         style=config.html.style,

--- a/tests/unit/test_typeset_default.py
+++ b/tests/unit/test_typeset_default.py
@@ -475,3 +475,14 @@ def test_type_schema(dataframe: pd.DataFrame, column: str, type_schema: dict):
     assert prof.typeset.type_schema[column] == prof.typeset._get_type(
         type_schema[column]
     )
+
+
+def test_type_schema_with_null_column():
+    df = pd.DataFrame({"null_col": [None] * 100})
+    prof = ProfileReport(df, type_schema={"null_col": "datetime"})
+    description = prof.description_set
+    assert description.variables["null_col"]["type"] == "Unsupported"
+
+    prof = ProfileReport(df, type_schema={"null_col": "numeric"})
+    description = prof.description_set
+    assert description.variables["null_col"]["type"] == "Unsupported"


### PR DESCRIPTION
Type schema did not check for empty columns leading to errors when trying to calculate some metrics over it. Also updates the type of an unsupported column when the type was defined by the user.
e.g. for columns:
```python
df = pd.DataFrame({
    'date': ['0001-01-01', '9999-12-31', '2012-10-03', '2017-10-03', '2022-10-03', '2022-10-04'],
    'null': [None]*6,
})
```
![image](https://github.com/user-attachments/assets/3697e895-cf94-4870-8e2a-c0b7214907b4)
