### PR TITLE
fix: add numba as a flavour to avoid errors related with deprecated methods due to dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,27 +1,33 @@
-scipy>=1.4.1, <1.14
+scipy>=1.4.1, <1.16
 pandas>1.1, <3, !=1.4.0
-matplotlib>=3.5, <3.10
+matplotlib>=3.5, <3.9
 pydantic>=2
 PyYAML>=5.0.0, <6.1
 jinja2>=2.11.1, <3.2
-visions[type_image_path]>=0.7.5, <0.7.7
+visions[type_image_path]>=0.7.5, <0.8.0
 numpy>=1.16.0, <2.2
+
 # Could be optional
 # Related to HTML report
 htmlmin==0.1.12
+
 # Correlations
 phik>=0.11.1,<0.13
+
 # Examples
 requests>=2.24.0, <3
+
 # Progress bar
 tqdm>=4.48.2, <5
 seaborn>=0.10.1, <0.14
 multimethod>=1.4, <2
+
 # metrics
 statsmodels>=0.13.2, <1
+
 # type checking
 typeguard>=3, <5
 imagehash==4.3.1
 wordcloud>=1.9.3
 dacite>=1.8
-numba>=0.56.0, <1
+#numba>=0.56.0, <1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=1.4.1, <1.16
 pandas>1.1, <3, !=1.4.0
-matplotlib>=3.5, <3.9
+matplotlib>=3.5
 pydantic>=2
 PyYAML>=5.0.0, <6.1
 jinja2>=2.11.1, <3.2

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
         "unicode": [
             "tangled-up-in-unicode==0.2.0",
         ],
+        "numba": [
+            "numba>=0.56.0, <1",
+        ]
     },
     package_data={
         "ydata_profiling": ["py.typed"],

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         ],
         "numba": [
             "numba>=0.56.0, <1",
-        ]
+        ],
     },
     package_data={
         "ydata_profiling": ["py.typed"],

--- a/src/ydata_profiling/__init__.py
+++ b/src/ydata_profiling/__init__.py
@@ -22,6 +22,7 @@ if spec is not None:
 spec_numba = importlib.util.find_spec("numba")
 if spec_numba is not None:
     from numba.core.errors import NumbaDeprecationWarning  # isort:skip # noqa
+
     warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
 
 __all__ = [

--- a/src/ydata_profiling/__init__.py
+++ b/src/ydata_profiling/__init__.py
@@ -2,12 +2,8 @@
 
 .. include:: ../../README.md
 """
-
 # ignore numba warnings
 import warnings  # isort:skip # noqa
-from numba.core.errors import NumbaDeprecationWarning  # isort:skip # noqa
-
-warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
 
 import importlib.util  # isort:skip # noqa
 
@@ -23,6 +19,10 @@ spec = importlib.util.find_spec("pyspark")
 if spec is not None:
     import ydata_profiling.model.spark  # isort:skip  # noqa
 
+spec_numba = importlib.util.find_spec("numba")
+if spec_numba is not None:
+    from numba.core.errors import NumbaDeprecationWarning  # isort:skip # noqa
+    warnings.simplefilter("ignore", category=NumbaDeprecationWarning)
 
 __all__ = [
     "pandas_decorator",


### PR DESCRIPTION
The dependency on visions package is leading to an error whenever numba installed version is >=0.59. 

To support python 3.12, numba version is required to be at least 0.59. 