### PR TITLE
fix: setuptools installed if missing for python >= 3.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
+import sys
 from pathlib import Path
+
+# Ensure setuptools is installed for Python 3.12+
+if sys.version_info >= (3, 12):
+    try:
+        import setuptools
+    except ImportError:
+        import subprocess
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "setuptools"])
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
Fixes #1618 adding `setuptools` as an optional requirement only if Python version is >= 3.12.

This was already being taken care off at #1619, but it seems this merge request was abandoned.

If there is a more appropriate way to do this, please share and I will implement it.