### PR TITLE
chore: add permissions to the release file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,15 +72,15 @@ jobs:
   publish-pypi:
     name: Publish packages to PyPi
     runs-on: ubuntu-22.04
-
     needs: package
-
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/download-artifact@v4
       with:
         name: built-artifacts
         path: dist/
-
     - uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist/


### PR DESCRIPTION
Fix the pipeline error 
Error: Trusted publishing exchange failure: 
OpenID Connect token retrieval failed: GitHub: missing or insufficient OIDC token permissions, the ACTIONS_ID_TOKEN_REQUEST_TOKEN environment variable was unset

Link: https://github.com/ydataai/ydata-profiling/actions/runs/13933637673/job/38996679548